### PR TITLE
ElasticLog Manager Concurrency

### DIFF
--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/src/main/java/dev/galasa/elasticlog/internal/ElasticLogManagerImpl.java
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/src/main/java/dev/galasa/elasticlog/internal/ElasticLogManagerImpl.java
@@ -242,7 +242,6 @@ public class ElasticLogManagerImpl extends AbstractManager {
 			client.postJson(index + "/_doc/" + testCase + testingEnvironment, request, false);
 
 		} catch (HttpClientException e) {
-			e.printStackTrace();
 			logger.info("ElasticLog Manager failed to send information to Elastic Endpoint");
 		} catch (URISyntaxException e) {
 			logger.info("ElasticLog Manager failed to send parse URI of Elastic Endpoint");

--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/src/main/java/dev/galasa/elasticlog/internal/ElasticLogManagerImpl.java
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/src/main/java/dev/galasa/elasticlog/internal/ElasticLogManagerImpl.java
@@ -233,33 +233,16 @@ public class ElasticLogManagerImpl extends AbstractManager {
 			//Send document to index
 			client.postJson(index + "/_doc", request, false);
         
+			//Change index to latest document index
 			index = index + "_latest";
-
-			String id = null;
-			HttpClientResponse<String> response = client.head(endpoint + "/" + index);
-			if (response.getStatusCode() != 404) {
-				//Obtain id of document if test case is already recorded
-				String testCase = (String) this.runProperties.get("testCase");
-				String testingEnvironment = (String) this.runProperties.get("testingEnvironment");
-				String searchResponse = client.get(index + "/_search?q=testCase:" + testCase + 
-													" testingEnvironment:" + testingEnvironment + 
-													"&default_operator=AND");
-				if (searchResponse.contains(testCase)) {
-					JsonObject json = this.gson.fromJson(searchResponse, JsonObject.class);
-					id = json.get("hits").getAsJsonObject().get("hits").getAsJsonArray()
-										.get(0).getAsJsonObject().get("_id").getAsString();
-				}
-			}
-            
-			//Update document if already present or send new document
-			if (id != null) {
-				JsonObject update = new JsonObject();
-				update.add("doc", gson.fromJson(request, JsonObject.class));
-				client.postJson(index + "/_update/" + id, gson.toJson(update), false);
-			} else
-				client.postJson(index + "/_doc", request, false);
+		 	String testCase = (String) this.runProperties.get("testCase");
+		 	String testingEnvironment = (String) this.runProperties.get("testingEnvironment");
+		 	
+		 	//Create new doc if doesnt exist, updates if doc already exists
+			client.postJson(index + "/_doc/" + testCase + testingEnvironment, request, false);
 
 		} catch (HttpClientException e) {
+			e.printStackTrace();
 			logger.info("ElasticLog Manager failed to send information to Elastic Endpoint");
 		} catch (URISyntaxException e) {
 			logger.info("ElasticLog Manager failed to send parse URI of Elastic Endpoint");


### PR DESCRIPTION
Found that posting with a unique combination of testcase and test environment as a document id forces an update when the id already exists. Elasticsearch's internal concurrency allows for only one of these requests to be processed at a time