### PR TITLE
Allow for 3270 terminals not to auto connect for long running tests.

### DIFF
--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/ITerminal.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/ITerminal.java
@@ -13,6 +13,10 @@ public interface ITerminal {
 
     boolean isConnected();
 
+    void connect() throws NetworkException;
+
+    void disconnect() throws InterruptedException;
+
     ITerminal waitForKeyboard() throws TimeoutException, KeyboardLockedException, InterruptedException;
 
     ITerminal positionCursorToFieldContaining(@NotNull String searchText)

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/Zos3270Terminal.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/Zos3270Terminal.java
@@ -33,5 +33,9 @@ public @interface Zos3270Terminal {
      * The tag of the zOS Image for terminal this variable is to be populated with
      */
     String imageTag() default "primary";
+    /**
+     * The tag of the zOS Image for terminal this variable is to be populated with
+     */
+    boolean autoConnect() default true;
 
 }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/Zos3270Terminal.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/Zos3270Terminal.java
@@ -34,7 +34,7 @@ public @interface Zos3270Terminal {
      */
     String imageTag() default "primary";
     /**
-     * The tag of the zOS Image for terminal this variable is to be populated with
+     * Allow user to choose if the terminal autoconnects in provision start stage
      */
     boolean autoConnect() default true;
 

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/Zos3270ManagerImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/Zos3270ManagerImpl.java
@@ -49,7 +49,7 @@ public class Zos3270ManagerImpl extends AbstractManager implements IZos3270Manag
 
     private IZosManagerSpi                              zosManager;
 
-    private List<Zos3270TerminalImpl>                   terminals     = new ArrayList<>();
+    private ArrayList<Zos3270TerminalImpl>              terminals     = new ArrayList<>();
 
     private int                                         terminalCount = 0;
 

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/Zos3270ManagerImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/Zos3270ManagerImpl.java
@@ -49,7 +49,7 @@ public class Zos3270ManagerImpl extends AbstractManager implements IZos3270Manag
 
     private IZosManagerSpi                              zosManager;
 
-    private HashMap<Zos3270TerminalImpl, Boolean>       terminals     = new HashMap<>();
+    private List<Zos3270TerminalImpl>                   terminals     = new ArrayList<>();
 
     private int                                         terminalCount = 0;
 
@@ -116,8 +116,7 @@ public class Zos3270ManagerImpl extends AbstractManager implements IZos3270Manag
 
         // *** Default the tag to primary
         String tag = defaultString(terminalAnnotation.imageTag(), "primary");
-
-        // boolean for autoconnect at provision start
+        // *** Default the tag to primary
         boolean autoConnect = terminalAnnotation.autoConnect();
 
         // *** Ask the zosManager for the image for the Tag
@@ -129,9 +128,9 @@ public class Zos3270ManagerImpl extends AbstractManager implements IZos3270Manag
             String terminaId = "term" + (terminalCount);
 
             Zos3270TerminalImpl terminal = new Zos3270TerminalImpl(terminaId, host.getHostname(), host.getTelnetPort(),
-                    host.isTelnetPortTls(), getFramework());
+                    host.isTelnetPortTls(), getFramework(), autoConnect);
 
-            this.terminals.put(terminal, autoConnect);
+            this.terminals.add(terminal);
             logger.info("Generated a terminal for zOS Image tagged " + tag);
 
             return terminal;
@@ -147,9 +146,9 @@ public class Zos3270ManagerImpl extends AbstractManager implements IZos3270Manag
         }
 
         logger.info("Connecting zOS3270 Terminals");
-        for (Zos3270TerminalImpl terminal : terminals.keySet()) {
+        for (Zos3270TerminalImpl terminal : terminals) {
             try {
-                if (terminals.get(terminal)) {
+                if (terminal.doAutoConnect()) {
                     terminal.connect();
                     logger.trace("Connected zOS 3270 Terminal " + terminal.getId());
                 } else {
@@ -165,7 +164,7 @@ public class Zos3270ManagerImpl extends AbstractManager implements IZos3270Manag
     @Override
     public void provisionStop() {
         logger.trace("Disconnecting terminals");
-        for (Zos3270TerminalImpl terminal : terminals.keySet()) {
+        for (Zos3270TerminalImpl terminal : terminals) {
             try {
                 terminal.flushTerminalCache();
                 terminal.disconnect();

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
@@ -40,12 +40,14 @@ public class Terminal implements ITerminal {
         screen = new Screen(80, 24, this.network);
     }
 
+    @Override
     public synchronized void connect() throws NetworkException {
         connected = network.connectClient();
         networkThread = new NetworkThread(screen, network, network.getInputStream());
         networkThread.start();
     }
 
+    @Override
     public void disconnect() throws InterruptedException {
         connected = false;
         if (network != null) {

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Zos3270TerminalImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Zos3270TerminalImpl.java
@@ -63,12 +63,14 @@ public class Zos3270TerminalImpl extends Terminal implements IScreenUpdateListen
     private URL                            liveTerminalUrl;
     private int                            liveTerminalSequence;
     private boolean                        logConsoleTerminals;
+    private boolean                        autoConnect;
 
-    public Zos3270TerminalImpl(String id, String host, int port, boolean tls, IFramework framework)
+    public Zos3270TerminalImpl(String id, String host, int port, boolean tls, IFramework framework, boolean autoConnect)
             throws Zos3270ManagerException, InterruptedException {
         super(host, port, tls);
         this.terminalId = id;
         this.runId = framework.getTestRunName();
+        this.autoConnect = autoConnect;
 
         this.cts = framework.getConfidentialTextService();
         this.applyCtf = ApplyConfidentialTextFiltering.get();
@@ -104,6 +106,10 @@ public class Zos3270TerminalImpl extends Terminal implements IScreenUpdateListen
         }
 
         logConsoleTerminals = LogConsoleTerminals.get();
+    }
+
+    public boolean doAutoConnect() {
+        return this.autoConnect;
     }
 
     @Override


### PR DESCRIPTION
Terminals take up slots and resources to run. In longer running tests, 3270 terminals might want to be connected and disconnected by the user.