### PR TITLE
Added clusterid for unmanaged images

### DIFF
--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/internal/ZosManagerImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zos/internal/ZosManagerImpl.java
@@ -427,8 +427,9 @@ public class ZosManagerImpl extends AbstractManager implements IZosManagerSpi {
         if (zosImage != null) {
             return zosImage;
         }
-        
-        ZosBaseImageImpl image =  new ZosDseImageImpl(this, imageId, null);
+
+        String clusterId = DseClusterIdForTag.get(imageId);
+        ZosBaseImageImpl image =  new ZosDseImageImpl(this, imageId, clusterId);
         this.images.put(image.getImageID(), image);
         return image;
     }


### PR DESCRIPTION
Small change for unmanaged images used through the ZosManagerSpi which checks the image id for clusterid. This is required for any images that are called through SPI that want to use the zosmf console