### PR TITLE
Allow invalid Order bytes in 3270 datastreams

### DIFF
--- a/changeLogs/changes-0.8.0.md
+++ b/changeLogs/changes-0.8.0.md
@@ -6,3 +6,4 @@
 | JATconv | Handle READ BUFFER and rejected device selection |
 | 258 | Refactor zOS TSO and UNIX command managers |
 | 246 | New TPI in Artifact manager to make streaming text content a single step process |
+| JATconv | The 3270 Manager will no longer throw an Exception for an invalid Order byte, it will replace it with a space on the screen and write a trace message to the log |

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/comms/NetworkThread.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/comms/NetworkThread.java
@@ -186,7 +186,8 @@ public class NetworkThread extends Thread {
                         break;
                     default:
                         String byteHex = Hex.encodeHexString(new byte[] { orderByte });
-                        throw new DatastreamException("Unrecognised order byte 0x" + byteHex);
+                        logger.trace("Invalid byte detected in datastream, unrecognised byte order or text byte - 0x" + byteHex);
+                        order = new OrderText(" ");
                 }
                 orders.add(order);
             } else {


### PR DESCRIPTION
Signed-off-by: Michael Baylis <Michael.Baylis@uk.ibm.com>