### PR TITLE
Initial commit of Docker configs uncluding volumes and envs

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/DockerContainerConfig.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/DockerContainerConfig.java
@@ -1,0 +1,19 @@
+package dev.galasa.docker;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import dev.galasa.docker.internal.DockerManagerField;
+import dev.galasa.framework.spi.ValidAnnotatedFields;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+@ValidAnnotatedFields({ IDockerContainerConfig.class })
+@DockerManagerField
+public @interface DockerContainerConfig {
+
+    public DockerVolume[] dockerVolumes() default {};
+    
+}

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/DockerVolume.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/DockerVolume.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed Materials - Property of IBM
+ * 
+ * (c) Copyright IBM Corp. 2021.
+ */
+package dev.galasa.docker;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import dev.galasa.docker.internal.DockerManagerField;
+import dev.galasa.framework.spi.ValidAnnotatedFields;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+@ValidAnnotatedFields({ IDockerVolume.class })
+@DockerManagerField
+public @interface DockerVolume {
+
+    /**
+     * If a volume name is passed, the mount will be read only. If no name is passed then a volume name will be generated
+     * This generated volume will be labeled and monitored after the test has finished and cleaned up by a user defined
+     * wait duration.
+     * 
+     * @return
+     */
+    public String volumeName() default "";
+
+    /**
+     * Where to mount the volume on the container.
+     * 
+     * @return
+     */
+    public String mountPath();
+
+    /**
+     * The <code>dockerEngineTag</code> will be used in the future so that a volume can be allocated on a specific Docker Engine type.
+     * You would not normally need to provide a Docker Engine tag.
+     * 
+     * @return
+     */
+    public String dockerEngineTag() default "PRIMARY";
+
+    /**
+     * The volume will not be removed by the end of test class, but later from resource management. Default will be 24 hours until removed 
+     * but is user defined.
+     * 
+     * @return
+     */
+    public boolean persist() default false;
+
+
+}

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/IDockerContainer.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/IDockerContainer.java
@@ -79,6 +79,14 @@ public interface IDockerContainer {
 	 * @throws DockerManagerException
 	 */
 	public void start() throws DockerManagerException;
+
+	/**
+	 * Start the Docker Container with a provided galasa DockerContainerConfig. This will stop and remove
+	 * any previous containers.
+	 * 
+	 * @throws DockerManagerException
+	 */
+	public void startWithConfig(IDockerContainerConfig config) throws DockerManagerException;
 	
 	/**
 	 * Stop the Docker Container.  The Docker Manager does not validate that the 

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/IDockerContainerConfig.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/IDockerContainerConfig.java
@@ -1,0 +1,14 @@
+package dev.galasa.docker;
+
+import java.util.HashMap;
+import java.util.List;
+
+public interface IDockerContainerConfig {
+
+    public void setEnvs(HashMap<String,String> envs);
+
+    public HashMap<String,String> getEnvs();
+
+    public List<IDockerVolume> getVolumes();
+    
+}

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/IDockerVolume.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/IDockerVolume.java
@@ -1,0 +1,11 @@
+package dev.galasa.docker;
+
+public interface IDockerVolume {
+
+    public String getVoumeName();
+
+    public String getMountPath();
+
+    public boolean readOnly();
+    
+}

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerContainerConfigImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerContainerConfigImpl.java
@@ -1,0 +1,33 @@
+package dev.galasa.docker.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import dev.galasa.docker.IDockerContainerConfig;
+import dev.galasa.docker.IDockerVolume;
+
+public class DockerContainerConfigImpl implements IDockerContainerConfig {
+    private List<IDockerVolume> volumes = new ArrayList<>();
+    private HashMap<String,String> envs = new HashMap<>();
+
+    public DockerContainerConfigImpl(List<IDockerVolume> volumes) {
+        this.volumes = volumes;
+    }
+
+    @Override
+    public void setEnvs(HashMap<String, String> envs) {
+       this.envs = envs;
+    }
+
+    @Override
+    public HashMap<String,String> getEnvs() {
+        return this.envs;
+    }
+
+    @Override
+    public List<IDockerVolume> getVolumes() {
+        return this.volumes;
+    }
+    
+}

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerEngineImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerEngineImpl.java
@@ -12,6 +12,7 @@ import java.net.URISyntaxException;
 
 import javax.validation.constraints.NotNull;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -224,6 +225,37 @@ public class DockerEngineImpl implements IDockerEngine {
 	 */
 	public JsonObject getImage(@NotNull String imageName) throws DockerManagerException {
 		return getJson("/images/" + imageName + "/json");
+	}
+
+	public JsonObject getVolume(String volumeName) throws DockerManagerException {
+		return getJson("/volumes/" + volumeName);
+	}
+
+	public String deleteVolume(String volumeName) throws DockerManagerException {
+		return deleteString("/volumes/" + volumeName);
+	}
+
+	/**
+	 * Create a volume with a defined name. The volume will not be tied to the test as a resource to be cleaned up
+	 * at the end of test. Instead it will be monitored and cleaned up from a user defined CPS property.
+	 * 
+	 * @param volumeName
+	 * @return
+	 * @throws DockerManagerException
+	 */
+	public JsonObject createVolume(String volumeName) throws DockerManagerException {
+		JsonObject data = new JsonObject();
+		if (!"".equals(volumeName)) {
+			data.addProperty("Name", volumeName);
+		}
+		
+		JsonObject labels = new JsonObject();
+		labels.addProperty("GALASA", "GALASA");
+		labels.addProperty("RUN_ID", framework.getTestRunName());
+
+		data.add("Labels", labels);
+
+		return postJson("/volumes/create", data);
 	}
 
 	/**

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerVolumeImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerVolumeImpl.java
@@ -1,0 +1,73 @@
+package dev.galasa.docker.internal;
+
+import com.google.gson.JsonObject;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import dev.galasa.docker.DockerManagerException;
+import dev.galasa.docker.IDockerVolume;
+import dev.galasa.framework.spi.IFramework;
+
+public class DockerVolumeImpl implements IDockerVolume {
+    private final String volumeName;
+    private final String mountPath;
+    private final DockerEngineImpl engine;
+    private final boolean readOnly;
+
+    private static final Log logger = LogFactory.getLog(DockerVolumeImpl.class);
+
+    public DockerVolumeImpl(String volumeName, String mountPath, DockerEngineImpl engine)
+            throws DockerManagerException {
+
+        // Non Galasa made volumes should not be edited by Galasa run containers.
+        if ("".equals(volumeName)) {
+            this.readOnly = false;
+            logger.info("Generating volume");
+
+            // If no named passed, Docker will name the volume. We will add galasa labels.
+            JsonObject json = engine.createVolume(volumeName);
+            this.volumeName = json.get("Name").getAsString();
+        } else {
+            this.volumeName = volumeName;
+            this.readOnly = true;
+        }
+   
+        this.mountPath = mountPath;
+        this.engine = engine;
+
+        if(!doesVolumeExist()) {
+            logger.error("No volume found with name: " + this.volumeName);
+            throw new DockerManagerException("Could not find volume with name: " + this.volumeName);
+            
+        }
+        logger.info("Existing volume found.");
+    }
+
+    @Override
+    public String getVoumeName() {
+        return this.volumeName;
+    }
+
+    @Override
+    public String getMountPath() {
+        return this.mountPath;
+    }
+
+    @Override
+    public boolean readOnly() {
+        return this.readOnly;
+    }
+
+    public boolean doesVolumeExist() throws DockerManagerException {
+        if (engine.getVolume(this.volumeName) != null) {
+            return true;   
+        }
+        return false;
+    }
+
+    public void discard() throws DockerManagerException {
+        engine.deleteVolume(this.volumeName);
+    }
+    
+}

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/IDockerEnvironment.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/IDockerEnvironment.java
@@ -72,6 +72,15 @@ public interface IDockerEnvironment {
 	//public void preAllocate(Resource rm) throws ResourceManagementException;
 
 	/**
+	 * Allocates a docker volume with a passed name. If the volume already exsists on the Engine, that volume will be used.
+	 * 
+	 * @param volumeName
+	 * @return
+	 * @throws DockerProvisionException
+	 */
+	public DockerVolumeImpl allocateDockerVolume(String volumeName, String mountPath, String DockerEngineTag, boolean persist) throws DockerProvisionException;
+
+	/**
 	 *  Free up the docker slot used to house a docker container.
 	 * 
 	 * @param dockerSlot


### PR DESCRIPTION
Signed-off-by: James Davies <jdavies47@hotmail.co.uk>

Draft pull request. DO NOT MERGE.

Initial commit for docker config and docker volumes. Was desgined with three Docker volume use cases in mind:
1. Mounting configuration - in this usecase any volume to be mounted contains configuration data and must not be edited by the running container, as this could affect parallelization of test running. Therefore, in the DockerVolume annotation, if a volume name is provided (aka already exists), the mount will be read only.
2. Sharing volumes - when a volume is required for multiple containers to use to share data. This shoult not be a provided volume, so it is expected that a volume name will not be passed to the DockerVolume annotation, and the docker engine will generate a name. This volume will be tagged for later reference. Current limitation is that the config used to provision the volume must be used for all containers wanting to mount the same volume. This results in the path having to be the same in all containers.
3. Persisting data - There may be a use case for a volume to exsist outside the life span of the test. For this I have encorparated a boolean called persist on the DockerVolume annotation. This is not indefinate, but controlled by resource management. A good default would probably be 24 hours, but can utimately be set by the user with a CPS property.