### PR TITLE
Build Fix

### DIFF
--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager/src/main/java/dev/galasa/cicsts/ceci/internal/CeciImpl.java
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager/src/main/java/dev/galasa/cicsts/ceci/internal/CeciImpl.java
@@ -30,7 +30,7 @@ import dev.galasa.zos3270.TimeoutException;
 import dev.galasa.zos3270.spi.NetworkException;
 
 /**
- * Implementation of {@link ICECI}
+ * Implementation of {@link ICeci}
  */
 public class CeciImpl implements ICeci {
     
@@ -982,7 +982,7 @@ public class CeciImpl implements ICeci {
     /**
      * Is HEX on. Disruptive, returns the EIB screen  
      * @return
-     * @throws CECIException
+     * @throws CeciException
      */
     protected boolean isHexOn() throws CeciException {
         try {
@@ -995,7 +995,7 @@ public class CeciImpl implements ICeci {
     /**
      * Set HEX on. Disruptive, returns the EIB screen  
      * @return
-     * @throws CECIException
+     * @throws CeciException
      */
     protected ICicsTerminal hexOn() throws CeciException {
         try {
@@ -1011,7 +1011,7 @@ public class CeciImpl implements ICeci {
     /**
      * Set HEX off. Disruptive, returns the EIB screen  
      * @return
-     * @throws CECIException
+     * @throws CeciException
      */
     protected ICicsTerminal hexOff() throws CeciException {
         try {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/bnd.bnd
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/bnd.bnd
@@ -2,7 +2,4 @@
 Bundle-Name: Galasa Liberty Manager
 Export-Package: dev.galasa.liberty,\
     dev.galasa.liberty.spi
-Import-Package: dev.galasa,\
-    dev.galasa.framework.spi,
-    javax.validation.constraints;resolution:=optional,\
-    org.apache.commons.logging
+Import-Package: dev.galasa

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.manager/bnd.bnd
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.manager/bnd.bnd
@@ -1,21 +1,21 @@
 -snapshot: ${tstamp}
 Bundle-Name: Galasa zOS Liberty Manager
-Export-Package: dev.galasa.zosliberty
-Import-Package: com.google.gson,\
-    dev.galasa,\
+Export-Package: dev.galasa.zosliberty,\
+    dev.galasa.zosliberty.spi
+Import-Package: dev.galasa,\
     dev.galasa.framework.spi,\
     dev.galasa.framework.spi.language,\
     dev.galasa.zos,\
     dev.galasa.zos.spi,\
     dev.galasa.zosfile,\
     dev.galasa.zosfile.spi,\
-    dev.galasa.zosmf,\
-    dev.galasa.zosmf.spi,\
-    dev.galasa.zosunixcommand,\
-    dev.galasa.zosunixcommand.spi,\
+    dev.galasa.zosliberty.spi,\
     javax.validation.constraints;resolution:=optional,\
-    org.apache.commons.lang3,\
-    org.apache.commons.lang3.math,\
+    javax.xml.parsers,\
+    javax.xml.transform,\
+    javax.xml.transform.dom,\
+    javax.xml.transform.stream,\
     org.apache.commons.logging,\
-    org.osgi.framework
+    org.w3c.dom,\
+    org.xml.sax
 


### PR DESCRIPTION
* Corrected incorrect formatting for the bnd in `dev.galasa.liberty.manager` (no slash after dev.galasa.liberty.manager).
    * Upon closer inspection, realised that the maven-built bundle manifest does not list the same imports, so, adjusted the bnd to match the maven build.
* Corrected the imports and exports for the bnd in `dev.galasa.zosliberty.manager`
* Corrected Javadoc errors