### PR TITLE
Headers are duplicated in HTTPManager

### DIFF
--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/internal/HttpClientImpl.java
@@ -807,9 +807,6 @@ public class HttpClientImpl implements IHttpClient {
     }
 
     private CloseableHttpResponse execute(HttpUriRequest request) throws HttpClientException {
-        for (Header header : commonHeaders) {
-            request.addHeader(header);
-        }
         this.build();
         try {
             return httpClient.execute(request, httpContext);


### PR DESCRIPTION
If test code adds a common header then HTTPManager will duplicate it.  Depending on the server this can result in either:

a) nothing and the duplicate is ignored
b) the value is repeated

This fixes that problem.  Kudos to @jamesabdulrahman for finding the problem