### PR TITLE
Remove needed dependency

### DIFF
--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/build.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/build.gradle
@@ -9,5 +9,4 @@ version = '0.15.0-SNAPSHOT'
 dependencies {
     implementation project(':galasa-managers-core-parent:dev.galasa.artifact.manager')
     implementation project(':galasa-managers-core-parent:dev.galasa.core.manager')
-    implementation 'org.assertj:assertj-core:3.11.1'
 }


### PR DESCRIPTION
Artefact manager IVT has a dependency on assertJ but this is now handled by the IVT plugin so removing it from the project