### PR TITLE
Fix for isolated build

### DIFF
--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/build.gradle
@@ -9,7 +9,7 @@ version = '0.15.0'
 dependencies {
     api            project(':galasa-managers-zos-parent:dev.galasa.zos3270.common')
     api            project(':galasa-managers-zos-parent:dev.galasa.zos.manager')
-    api            'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'commons-codec:commons-codec:1.11'
     implementation 'commons-io:commons-io:2.6'
     


### PR DESCRIPTION
Simbank managers build was failing when using the full isolated zip. Changing gson from api to implementation fixes this (similar to previous issues).

Signed-off-by: Matthew Chivers <matthewchivers@outlook.com>