### PR TITLE
3270 Manager Fix, More 3270 IVT tests, VSAM IVT, Command IVT

### DIFF
--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerBatchIVT.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerBatchIVT.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2019.
+ * (c) Copyright IBM Corp. 2019-2021.
  */
 package dev.galasa.zos.manager.ivt;
 

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerFileVSAMIVT.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerFileVSAMIVT.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed Materials - Property of IBM
+ * 
+ * (c) Copyright IBM Corp. 2021.
+ */
+package dev.galasa.zos.manager.ivt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.apache.commons.logging.Log;
+
+import dev.galasa.ICredentialsUsernamePassword;
+import dev.galasa.Test;
+import dev.galasa.artifact.BundleResources;
+import dev.galasa.artifact.IBundleResources;
+import dev.galasa.artifact.TestBundleResourceException;
+import dev.galasa.core.manager.CoreManager;
+import dev.galasa.core.manager.ICoreManager;
+import dev.galasa.core.manager.Logger;
+import dev.galasa.core.manager.TestProperty;
+import dev.galasa.zos.IZosImage;
+import dev.galasa.zos.ZosImage;
+import dev.galasa.zosbatch.IZosBatch;
+import dev.galasa.zosbatch.ZosBatch;
+import dev.galasa.zosbatch.ZosBatchException;
+import dev.galasa.zosfile.IZosFileHandler;
+import dev.galasa.zosfile.IZosVSAMDataset;
+import dev.galasa.zosfile.IZosVSAMDataset.VSAMSpaceUnit;
+import dev.galasa.zosfile.ZosFileHandler;
+import dev.galasa.zosfile.ZosVSAMDatasetException;
+import dev.galasa.zosunixcommand.IZosUNIXCommand;
+import dev.galasa.zosunixcommand.ZosUNIXCommand;
+
+@Test
+public class ZosManagerFileVSAMIVT {
+    
+    private final String IMG_TAG = "PRIMARY";
+    
+    @Logger
+    public Log logger;
+    
+    @ZosImage(imageTag =  IMG_TAG)
+    public IZosImage imagePrimary;
+        
+    @ZosFileHandler
+    public IZosFileHandler fileHandler;
+    
+    @ZosBatch(imageTag = "PRIMARY")
+    public IZosBatch batch;
+
+    @BundleResources
+    public IBundleResources resources; 
+    
+    @CoreManager
+    public ICoreManager coreManager;
+    
+    @ZosUNIXCommand(imageTag = IMG_TAG)
+    public IZosUNIXCommand zosUNIXCommand;
+    
+    @TestProperty(prefix = "IVT.RUN",suffix = "NAME", required = false)
+    public String providedRunName;
+    
+    private String runName  = new String();
+
+    @Test
+    public void preFlightTests() throws Exception {
+        // Ensure we have the resources we need for testing
+        assertThat(imagePrimary).isNotNull();
+        assertThat(fileHandler).isNotNull();
+        assertThat(coreManager).isNotNull();
+        assertThat(resources).isNotNull();
+        assertThat(logger).isNotNull();
+        assertThat(imagePrimary.getDefaultCredentials()).isNotNull();
+        if (providedRunName != null) {
+        	runName = providedRunName;
+        }
+        else {
+        	runName = coreManager.getRunName();
+        }
+        logger.info("Using Run ID of: " + runName);
+    }
+    
+    /**
+     * Very Basic test method to create and delete a KSDS file
+     * Using IDCAMS to check our working
+     * @throws ZosVSAMDatasetException
+     * @throws ZosBatchException
+     * @throws TestBundleResourceException
+     * @throws IOException
+     */
+    @Test
+    public void basicKSDSDefine() throws ZosVSAMDatasetException, ZosBatchException, TestBundleResourceException, IOException {
+    	String DSName = "CTS.GALASA." + runName + ".KSDS";
+    	IZosVSAMDataset vsamDataSet = fileHandler.newVSAMDataset(DSName, imagePrimary);
+    	vsamDataSet.setSpace(VSAMSpaceUnit.CYLINDERS, 1, 1);
+    	vsamDataSet.setRecordSize(50, 101);
+    	vsamDataSet.create();
+    	
+    	assertThat(checkThatPDSExists(DSName)).isTrue();
+    	assertThat(vsamDataSet.exists()).isTrue();
+    	
+    	vsamDataSet.delete();
+    	
+    	assertThat(checkThatPDSExists(DSName)).isFalse();
+    	assertThat(vsamDataSet.exists()).isFalse();
+    }
+    
+    /**
+     * Run some JCL to check that a PDS has been created
+     * This is used to test that zosFile is working correctly
+     * @param dataset The name of the dataset that we want to test
+     * @return a boolean to signify that the dataset exists (or not)
+     * @throws TestBundleResourceException
+     * @throws IOException
+     * @throws ZosBatchException
+     */
+    private boolean checkThatPDSExists(String dataset) throws TestBundleResourceException, IOException, ZosBatchException {
+    	HashMap<String,Object> parms = new HashMap<>();
+    	parms.put("DATASET", dataset);
+    	String jcl = resources.retrieveSkeletonFileAsString("/resources/jcl/PDSCheck.jcl", parms);
+    	return(batch.submitJob(jcl, null).waitForJob() == 0);
+    }
+}

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerTSOCommandIVT.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/src/main/java/dev/galasa/zos/manager/ivt/ZosManagerTSOCommandIVT.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed Materials - Property of IBM
+ * 
+ * (c) Copyright IBM Corp. 2021.
+ */
+package dev.galasa.zos.manager.ivt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.logging.Log;
+
+import dev.galasa.Test;
+import dev.galasa.core.manager.CoreManager;
+import dev.galasa.core.manager.ICoreManager;
+import dev.galasa.core.manager.Logger;
+import dev.galasa.core.manager.TestProperty;
+import dev.galasa.zos.IZosImage;
+import dev.galasa.zos.ZosImage;
+import dev.galasa.zostsocommand.IZosTSOCommand;
+import dev.galasa.zostsocommand.ZosTSOCommand;
+import dev.galasa.zostsocommand.ZosTSOCommandException;
+
+@Test
+public class ZosManagerTSOCommandIVT {
+    
+    private final String IMG_TAG = "PRIMARY";
+    
+    @Logger
+    public Log logger;
+    
+    @ZosImage(imageTag =  IMG_TAG)
+    public IZosImage imagePrimary;
+   
+    @CoreManager
+    public ICoreManager coreManager;
+    
+    @ZosTSOCommand(imageTag =  IMG_TAG)
+    public IZosTSOCommand command;
+    
+    @TestProperty(prefix = "IVT.RUN",suffix = "NAME", required = false)
+    public String providedRunName;
+    
+    private String runName  = new String();
+
+    @Test
+    public void preFlightTests() throws Exception {
+        // Ensure we have the resources we need for testing
+        assertThat(imagePrimary).isNotNull();
+        assertThat(coreManager).isNotNull();
+        assertThat(logger).isNotNull();
+        assertThat(imagePrimary.getDefaultCredentials()).isNotNull();
+        if (providedRunName != null) {
+        	runName = providedRunName;
+        }
+        else {
+        	runName = coreManager.getRunName();
+        }
+        logger.info("Using Run ID of: " + runName);
+    }
+    
+    @Test
+    public void basicCommandExecution() throws ZosTSOCommandException  {
+    	String machineTime = command.issueCommand("TIME").trim();
+    	Calendar current = Calendar.getInstance();
+    	
+    	String pattern = "[A-Z0-9]+\\sTIME-([0-9:]+)\\s([AMP]+).\\s[A-Z0-9:-]+\\s[A-Z0-9:-]+\\s[A-Z0-9:-]+\\s([A-Z]+)\\s([0-9]+),([0-9]+)";
+    	final Pattern extractDate = Pattern.compile(pattern);
+    	Matcher m = extractDate.matcher(machineTime);
+    	assertThat(m.find()).isTrue();
+    	
+    	assertThat(m.group(5)).isEqualTo(Integer.toString(current.get(Calendar.YEAR)));
+    	assertThat(m.group(4)).isEqualTo(Integer.toString(current.get(Calendar.DAY_OF_MONTH)));
+    	assertThat(m.group(3)).isEqualToIgnoringCase(current.getDisplayName(Calendar.MONTH, Calendar.LONG, Locale.ENGLISH));
+    }
+   
+}

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/src/main/java/dev/galasa/zos3270/manager/ivt/Zos3270IVT.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/src/main/java/dev/galasa/zos3270/manager/ivt/Zos3270IVT.java
@@ -10,7 +10,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.commons.logging.Log;
 
 import dev.galasa.Test;
+import dev.galasa.core.manager.CoreManager;
+import dev.galasa.core.manager.ICoreManager;
 import dev.galasa.core.manager.Logger;
+import dev.galasa.core.manager.TestProperty;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 import dev.galasa.zos3270.ErrorTextFoundException;
@@ -36,6 +39,13 @@ public class Zos3270IVT {
     @Zos3270Terminal(imageTag = "PRIMARY")
     public ITerminal terminal;
     
+    @CoreManager
+    public ICoreManager coreManager;
+    
+    @TestProperty(prefix = "IVT.RUN",suffix = "NAME", required = false)
+    public String providedRunName;
+    private String runName  = new String();
+    
     private String applid = "IYK2ZNB5";
 
     @Test
@@ -44,6 +54,12 @@ public class Zos3270IVT {
         assertThat(image).as("zOS Image Field").isNotNull();
         assertThat(terminal).as("zOS 3270 Terminal Field").isNotNull();
         assertThat(terminal.isConnected()).isTrue();
+        if (providedRunName != null) {
+        	runName = providedRunName;
+        } else {
+        	runName = coreManager.getRunName();
+        }
+        logger.info("Using Run ID of: " + runName);
     }
 
     @Test
@@ -108,15 +124,20 @@ public class Zos3270IVT {
     public void mustBeABetterWayToTestEOF() throws TimeoutException, KeyboardLockedException, TerminalInterruptedException, NetworkException, FieldNotFoundException {
     	//hear me out.........
     	//create a TSQ called Hobbit containing THE RING
-    	terminal.type("CECI WRITEQ TS QUEUE(HOBBIT) FROM('THE RING')").enter().wfk().enter().wfk().pf3().wfk().clear().wfk();
+    	terminal.type("CECI WRITEQ TS QNAME(HOBBIT" + runName + ") FROM('THE RING')").enter().wfk().enter().wfk().pf3().wfk().clear().wfk();
     	//try and browse the queue - but get the name wrong - no rings here
     	terminal.type("CEBR BILBOBAGGINS").enter().wfk();
     	assertThat(terminal.retrieveScreen()).doesNotContain("THE RING");
     	//so erase that and try the hobbit queue
-    	terminal.home().eraseEof().type("HOBBIT").enter().wfk();
+    	terminal.home().eraseEof().type("HOBBIT"+runName).enter().wfk();
     	assertThat(terminal.retrieveScreen()).contains("THE RING");
     	//purge the queue so we can run again (YES I KNOW THIS WILL NOT  RUN IN PARALELL
     	terminal.home().tab().tab().type("purge").enter().wfk().pf3().wfk().clear();
+    }
+    
+    @Test
+    public void reportScreenTests() {
+    	
     }
     
 }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/ITerminal.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/ITerminal.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2019.
+ * (c) Copyright IBM Corp. 2019-2021.
  */
 package dev.galasa.zos3270;
 
@@ -41,7 +41,7 @@ public interface ITerminal {
      * @throws ErrorTextFoundException - One of the error strings were found, index of which is in the exception
      * @throws Zos3270Exception - general zos 3270 error
      */
-    ITerminal waitForTextInField(String[] ok, String[] error) throws TerminalInterruptedException, TextNotFoundException, ErrorTextFoundException, Zos3270Exception;
+    int waitForTextInField(String[] ok, String[] error) throws TerminalInterruptedException, TextNotFoundException, ErrorTextFoundException, Zos3270Exception;
 
     /**
      * @param ok - An array of text strings to find on the screen
@@ -53,7 +53,7 @@ public interface ITerminal {
      * @throws ErrorTextFoundException - One of the error strings were found
      * @throws Zos3270Exception - general zos 3270 error
      */
-    ITerminal waitForTextInField(String[] ok, String[] error, long timeoutInMilliseconds) throws TerminalInterruptedException, TextNotFoundException, ErrorTextFoundException, Zos3270Exception;
+    int waitForTextInField(String[] ok, String[] error, long timeoutInMilliseconds) throws TerminalInterruptedException, TextNotFoundException, ErrorTextFoundException, Zos3270Exception;
 
     ITerminal verifyTextInField(String string) throws TextNotFoundException;
 

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Screen.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Screen.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2020,2021.
+ * (c) Copyright IBM Corp. 2020-2021.
  */
 package dev.galasa.zos3270.spi;
 
@@ -938,13 +938,15 @@ public class Screen {
         keyboardLock.release();
     }
 
-    public void waitForTextInField(String text, long maxWait) throws TerminalInterruptedException, TextNotFoundException, Zos3270Exception {
-        waitForTextInField(new String[] {text}, null, maxWait);
+    public int waitForTextInField(String text, long maxWait) throws TerminalInterruptedException, TextNotFoundException, Zos3270Exception {
+        return waitForTextInField(new String[] {text}, null, maxWait);
     }
 
-    public void waitForTextInField(String[] ok, String[] error, long timeoutInMilliseconds) throws TerminalInterruptedException, TextNotFoundException, ErrorTextFoundException, Zos3270Exception {
-        try {
-            if (ScreenUpdateTextListener.waitForText(this, ok, error, timeoutInMilliseconds) < 0) {
+    public int waitForTextInField(String[] ok, String[] error, long timeoutInMilliseconds) throws TerminalInterruptedException, TextNotFoundException, ErrorTextFoundException, Zos3270Exception {
+        int foundIndex = -1;
+    	try {
+        	foundIndex = ScreenUpdateTextListener.waitForText(this, ok, error, timeoutInMilliseconds);
+            if (foundIndex < 0) {
                 if (ok != null && ok.length == 1 && error == null) {
                     throw new TextNotFoundException(CANT_FIND_TEXT + ok[0] + "'");
                 }
@@ -953,6 +955,7 @@ public class Screen {
         } catch(InterruptedException e) {
             throw new TerminalInterruptedException("Wait for text was interrupted", e);
         }
+        return foundIndex;
     }
 
 

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/spi/Terminal.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2019,2021.
+ * (c) Copyright IBM Corp. 2019-2021.
  */
 package dev.galasa.zos3270.spi;
 
@@ -213,16 +213,15 @@ public class Terminal implements ITerminal {
     }
 
     @Override
-    public ITerminal waitForTextInField(String[] ok, String[] error)
+    public int waitForTextInField(String[] ok, String[] error)
             throws TerminalInterruptedException, TextNotFoundException, ErrorTextFoundException, Zos3270Exception {
         return waitForTextInField(ok, error, this.defaultWaitTime);
     }
 
     @Override
-    public ITerminal waitForTextInField(String[] ok, String[] error, long timeoutInMilliseconds)
+    public int waitForTextInField(String[] ok, String[] error, long timeoutInMilliseconds)
             throws TerminalInterruptedException, TextNotFoundException, ErrorTextFoundException, Zos3270Exception {
-        screen.waitForTextInField(ok, error, timeoutInMilliseconds);
-        return this;
+        return screen.waitForTextInField(ok, error, timeoutInMilliseconds);
     }
 
     @Override


### PR DESCRIPTION
Javadoc for waitForText suggests that it should return an int to depict the field that was found.  However that isn't true - it was returning a ITerminal object.

I think what I have changed it to is the correct behaviour but will ask @Michael-Baylis for a review.  If wrong it's easy to change it back - TBC just requesting Mikes review on the change to the 3270Manager

also some additions to the 3270 IVT to cover the changed capability