### PR TITLE
fix to zosBatch 

### DIFF
--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/src/main/java/dev/galasa/zosbatch/rseapi/manager/internal/RseapiZosBatchJobImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/src/main/java/dev/galasa/zosbatch/rseapi/manager/internal/RseapiZosBatchJobImpl.java
@@ -695,6 +695,7 @@ public class RseapiZosBatchJobImpl implements IZosBatchJob {
 
     protected void archiveJobOutput() throws ZosBatchException {
         if (shouldArchive() && getStatus() != JobStatus.NOTFOUND && (!isArchived() || !this.jobComplete)) {
+        	retrieveOutput();
             Path rasPath = this.zosBatchManager.getCurrentTestMethodArchiveFolder();
             String folderName = this.jobname.getName() + "_" + this.jobid + "_" + this.retcode.replace(" ", "-").replace(StringUtils.repeat(QUERY, 4), "UNKNOWN");
             rasPath = rasPath.resolve(this.zosBatchManager.getZosManager().buildUniquePathName(rasPath, folderName));

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/src/test/java/dev/galasa/zosbatch/rseapi/manager/internal/TestRseapiZosBatchJobImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/src/test/java/dev/galasa/zosbatch/rseapi/manager/internal/TestRseapiZosBatchJobImpl.java
@@ -880,6 +880,7 @@ public class TestRseapiZosBatchJobImpl {
     
     @Test
     public void testArchiveJobOutput() throws Exception {
+    	Mockito.doReturn(zosBatchJobOutputMock).when(zosBatchJobSpy).retrieveOutput();
     	Whitebox.setInternalState(zosBatchJobSpy, "jobid", FIXED_JOBID);
     	Whitebox.setInternalState(zosBatchJobSpy, "retcode", FIXED_RETCODE_0000);
     	Mockito.doNothing().when(zosBatchJobSpy).saveOutputToResultsArchive(Mockito.any());

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/src/main/java/dev/galasa/zosbatch/zosmf/manager/internal/ZosmfZosBatchJobImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/src/main/java/dev/galasa/zosbatch/zosmf/manager/internal/ZosmfZosBatchJobImpl.java
@@ -808,6 +808,7 @@ public class ZosmfZosBatchJobImpl implements IZosBatchJob {
 
     protected void archiveJobOutput() throws ZosBatchException {
     	if (shouldArchive() && getStatus() != JobStatus.NOTFOUND && (!isArchived() || !this.jobComplete)) {
+    		retrieveOutput();
             String folderName = this.jobname.getName() + "_" + this.jobid + "_" + getRetcode().replace(" ", "-");
             Path rasPath = this.testMethodArchiveFolder.resolve(this.zosBatchManager.getZosManager().buildUniquePathName(testMethodArchiveFolder, folderName));
             saveOutputToResultsArchive(rasPath.toString());

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/src/test/java/dev/galasa/zosbatch/zosmf/manager/internal/TestZosmfZosBatchJobImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/src/test/java/dev/galasa/zosbatch/zosmf/manager/internal/TestZosmfZosBatchJobImpl.java
@@ -1000,6 +1000,7 @@ public class TestZosmfZosBatchJobImpl {
     
     @Test
     public void testArchiveJobOutput() throws Exception {
+    	Mockito.doReturn(zosBatchJobOutputMock).when(zosBatchJobSpy).retrieveOutput();
     	Whitebox.setInternalState(zosBatchJobSpy, "jobid", FIXED_JOBID);
     	Whitebox.setInternalState(zosBatchJobSpy, "retcode", FIXED_RETCODE_0000);
     	Mockito.doNothing().when(zosBatchJobSpy).saveOutputToResultsArchive(Mockito.any());


### PR DESCRIPTION
zosBatch doesn't honour archiveOutput() if the output hasn't been retrieved