### PR TITLE
Add "getJavaHome()" method

### DIFF
--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa Java Manager'
 
-version = '0.15.0'
+version = '0.17.0'
 
 dependencies {
     implementation  project(':galasa-managers-comms-parent:dev.galasa.http.manager')

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/src/main/java/dev/galasa/java/IJavaInstallation.java
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/src/main/java/dev/galasa/java/IJavaInstallation.java
@@ -18,7 +18,7 @@ public interface IJavaInstallation {
     String getJavaCommand() throws JavaManagerException;
 
     /**
-     * Provides the canonical "Java Home" directory location within the unpacked java archive.
+     * Provides the "Java Home" directory location within the unpacked java archive.
      * @return String 
      */
     String getJavaHome();

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/src/main/java/dev/galasa/java/IJavaInstallation.java
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/src/main/java/dev/galasa/java/IJavaInstallation.java
@@ -16,5 +16,6 @@ public interface IJavaInstallation {
     String getArchiveFilename() throws JavaManagerException;
     
     String getJavaCommand() throws JavaManagerException;
-    
+    String getJavaHome() throws JavaManagerException;
+
 }

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/src/main/java/dev/galasa/java/IJavaInstallation.java
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/src/main/java/dev/galasa/java/IJavaInstallation.java
@@ -16,6 +16,11 @@ public interface IJavaInstallation {
     String getArchiveFilename() throws JavaManagerException;
     
     String getJavaCommand() throws JavaManagerException;
-    String getJavaHome() throws JavaManagerException;
+
+    /**
+     * Provides the canonical "Java Home" directory location within the unpacked java archive.
+     * @return String 
+     */
+    String getJavaHome();
 
 }

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa Java Ubuntu Manager'
 
-version = '0.15.0'
+version = '0.17.0'
 
 dependencies {
     api project(':galasa-managers-unix-parent:dev.galasa.linux.manager')

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/src/main/java/dev/galasa/java/ubuntu/spi/JavaUbuntuInstallationImpl.java
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/src/main/java/dev/galasa/java/ubuntu/spi/JavaUbuntuInstallationImpl.java
@@ -287,7 +287,7 @@ public class JavaUbuntuInstallationImpl extends JavaInstallationImpl implements 
     }
 
     @Override
-    public String getJavaHome() throws JavaManagerException {
+    public String getJavaHome() {
         return this.javaHome.toString();
     }
 

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/src/main/java/dev/galasa/java/ubuntu/spi/JavaUbuntuInstallationImpl.java
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/src/main/java/dev/galasa/java/ubuntu/spi/JavaUbuntuInstallationImpl.java
@@ -286,4 +286,9 @@ public class JavaUbuntuInstallationImpl extends JavaInstallationImpl implements 
         }
     }
 
+    @Override
+    public String getJavaHome() throws JavaManagerException {
+        return this.javaHome.toString();
+    }
+
 }

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa Java Windows Manager'
 
-version = '0.15.0'
+version = '0.17.0'
 
 dependencies {
     api project(':galasa-managers-windows-parent:dev.galasa.windows.manager')

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/src/main/java/dev/galasa/java/windows/spi/JavaWindowsInstallationImpl.java
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/src/main/java/dev/galasa/java/windows/spi/JavaWindowsInstallationImpl.java
@@ -179,4 +179,9 @@ public class JavaWindowsInstallationImpl extends JavaInstallationImpl implements
         return this.javaHome.resolve("bin/java").toString();
     }
 
+    @Override
+    public String getJavaHome() throws JavaManagerException {
+        return this.javaHome.toString();
+    }
+
 }

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/src/main/java/dev/galasa/java/windows/spi/JavaWindowsInstallationImpl.java
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/src/main/java/dev/galasa/java/windows/spi/JavaWindowsInstallationImpl.java
@@ -180,7 +180,7 @@ public class JavaWindowsInstallationImpl extends JavaInstallationImpl implements
     }
 
     @Override
-    public String getJavaHome() throws JavaManagerException {
+    public String getJavaHome() {
         return this.javaHome.toString();
     }
 


### PR DESCRIPTION
Added method: `getJavaHome()` to enable tests to retrieve the directory of the unzipped java.