### PR TITLE
Fixed leading dot-slash problem when unpacking archive.

### DIFF
--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/src/main/java/dev/galasa/java/ubuntu/spi/JavaUbuntuInstallationImpl.java
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/src/main/java/dev/galasa/java/ubuntu/spi/JavaUbuntuInstallationImpl.java
@@ -41,7 +41,7 @@ public class JavaUbuntuInstallationImpl extends JavaInstallationImpl implements 
     private Path javaHome;
     private Path jacocoAgent;
 
-    private static final Pattern findHome = Pattern.compile("^(([a-zA-Z0-9\\-\\+\\._/ \\\\]*)?/)?\\Qbin/java\\E$", Pattern.MULTILINE);
+    private static final Pattern findHome = Pattern.compile("^(\\.\\/){0,1}(([a-zA-Z0-9\\-\\+\\._/ \\\\]*)?/)?\\Qbin/java\\E$", Pattern.MULTILINE);
 
     private final ArrayList<Path> jacocoExecs = new ArrayList<>();
     private int execFileNumber;
@@ -170,7 +170,7 @@ public class JavaUbuntuInstallationImpl extends JavaInstallationImpl implements 
                 Path targetHome = possibleJavaHomes.resolve(this.javaDirectoryName);
                 Path extractedHome = tempExtractDirectory;
 
-                String prefixDirectories = matcher.group(2);
+                String prefixDirectories = matcher.group(3);
                 if (prefixDirectories != null && !prefixDirectories.isEmpty()) {
                     if ("/".equals(prefixDirectories)) {
                         throw new JavaManagerException("Unexpected found Java home in the root directory of the archive, ie prefixed /");


### PR DESCRIPTION
Regex now allows for archives that were built without stripping the leading components (archives that output a dot-slash when unpacked).

> I found that some Java archives were built in such a way that they include the leading components `./` at the beginning. This broke when `SSHPath` tried to resolve the path, as it splits the path using the `/` - making the `.` it's own element. SSHPath then throws an error because it sees a single dot as a path element:
> ```
> for (final String part : this.nameElements) {
>     if (".".equals(part)) {
>         throw new InvalidPathException(path, "Path parts of '.' are not allowed");
>     }
> ```

I think a further change could be made to SSHPath itself so that it is more robust in identifying elements, but this regex change fixes this specific instance of the error.

Signed-off-by: Matthew Chivers <matthewchivers@outlook.com>