### PR TITLE
Created Get Framework method

### DIFF
--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/IGenericEcosystem.java
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/IGenericEcosystem.java
@@ -85,6 +85,11 @@ public interface IGenericEcosystem {
      */
     public void setCredsProperty(@NotNull String property, String value)  throws GalasaEcosystemManagerException;
     
+    /**
+     * Get instance of framework
+     * 
+     * @return  IFramework  Framework instance used by the ecosystem
+     */
     public IFramework getFramework();
     
     public String submitRun(String runType,

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/IGenericEcosystem.java
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/IGenericEcosystem.java
@@ -11,6 +11,7 @@ import javax.validation.constraints.NotNull;
 
 import com.google.gson.JsonObject;
 
+import dev.galasa.framework.spi.IFramework;
 import dev.galasa.zos.IZosImage;
 
 /**
@@ -83,6 +84,8 @@ public interface IGenericEcosystem {
      * @throws GalasaEcosystemManagerException if there is a problem accessing the CREDS
      */
     public void setCredsProperty(@NotNull String property, String value)  throws GalasaEcosystemManagerException;
+    
+    public IFramework getFramework();
     
     public String submitRun(String runType,
                           String requestor,

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/AbstractEcosystemImpl.java
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/AbstractEcosystemImpl.java
@@ -92,8 +92,6 @@ public abstract class AbstractEcosystemImpl implements IInternalEcosystem, IGene
 		return this.manager.getFramework();
 	}
     
-    
-    
     @Override
     public void addZosImageToCpsAsDefault(@NotNull IZosImage image) throws GalasaEcosystemManagerException {
         addZosImageToCps(image);

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/AbstractEcosystemImpl.java
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/AbstractEcosystemImpl.java
@@ -87,6 +87,12 @@ public abstract class AbstractEcosystemImpl implements IInternalEcosystem, IGene
         setCpsProperty("zos.cluster." + clusterId + ".images", sb.toString());
     }
     
+    @Override
+    public IFramework getFramework() {
+		return this.manager.getFramework();
+	}
+    
+    
     
     @Override
     public void addZosImageToCpsAsDefault(@NotNull IZosImage image) throws GalasaEcosystemManagerException {


### PR DESCRIPTION
In order to push data / files to the RAS, access to the framework is needed. e.g.:
```
Path RasArtifactsPath = IFramework.getResultArchiveStore().getStoredArtifactsRoot();
Files.write(RasArtifactsPath.resolve("example.log"), "content")
```

This `getFramework` method allows access to the `IFramework` instance being used within the ecosystem so that users of the ecosystem manager can write to the RAS easily.