### PR TITLE
Docker volume file permissions

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/src/main/java/dev/galasa/docker/manager/ivt/DockerManagerIVT.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/src/main/java/dev/galasa/docker/manager/ivt/DockerManagerIVT.java
@@ -293,5 +293,31 @@ public class DockerManagerIVT {
         container.startWithConfig(config1);
         assertThat(container.isRunning()).isEqualTo(true);
     }
+    
+    @Test
+    public void testFilePermissionsChange() throws DockerManagerException {
+    	IDockerVolume volume = config2.getVolumeByTag("testVolume");
+        volume.LoadFileAsString("AnotherConfig.cfg", "AdditionalStringConfigs");
+        volume.fileChmod("755", "AnotherConfig.cfg");
 
+        container.startWithConfig(config2);
+
+        IDockerExec cmd = container.exec("ls", "-l", "/tmp/testvol/AnotherConfig.cfg");
+        cmd.waitForExec();
+        assertThat(cmd.getCurrentOutput()).contains("-rwxr-xr-x");
+    }
+    
+    @Test
+    public void testFileOwnerChange() throws DockerManagerException {
+    	IDockerVolume volume = config2.getVolumeByTag("testVolume");
+        volume.LoadFileAsString("AnotherConfig.cfg", "AdditionalStringConfigs");
+        volume.fileChown("200", "AnotherConfig.cfg");
+
+        container.startWithConfig(config2);
+
+        IDockerExec cmd = container.exec("ls", "-l", "/tmp/testvol/AnotherConfig.cfg");
+        cmd.waitForExec();
+        assertThat(cmd.getCurrentOutput()).contains("200");
+    }
+    
 }

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/IDockerVolume.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/IDockerVolume.java
@@ -60,4 +60,23 @@ public interface IDockerVolume {
      */
     public void LoadFileAsString(String fileName, String data) throws DockerManagerException;
     
+    
+    /**
+     * Will execute a `chown USER:GROUP filename` on a file inside the volume.
+     * 
+     * @param userGroup
+     * @param filename
+     * @throws DockerManagerException
+     */
+    public void fileChown(String userGroup, String filename) throws DockerManagerException;
+    
+    /**
+     * Will execute a `chmod XXX filename` where the XXX is the permission string, on a file inside a volume.
+     * 
+     * @param permissions
+     * @param filename
+     * @throws DockerManagerException
+     */
+    public void fileChmod(String permissions, String filename) throws DockerManagerException;
+    
 }

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerImageBuilderImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerImageBuilderImpl.java
@@ -29,6 +29,18 @@ public class DockerImageBuilderImpl implements IDockerImageBuilder {
     public DockerImageBuilderImpl(DockerEngineImpl engine) {
         this.engine = engine;
     }
+    
+    /**
+     * Build a new image on the docker engine. A dockerfile MUST be passed.
+     * @param imageName
+     * @param dockerfile
+     * @throws DockerMangerException
+     */
+    @Override
+    public void buildImage(String imageName, InputStream dockerfile)throws DockerManagerException {
+    	buildImage(imageName, dockerfile, null);
+    }
+    
 
     /**
      * Build a new image on the docker engine. A dockerfile MUST be passed. Any resources required to build the 
@@ -80,15 +92,17 @@ public class DockerImageBuilderImpl implements IDockerImageBuilder {
             IOUtils.copy(dockerfile, tOut);
             tOut.closeArchiveEntry();
 
-            // Put the rest of the resources in a flat dir
-            for (String fileName : buildResources.keySet()) {
-                TarArchiveEntry entry = new TarArchiveEntry(fileName);
-                entry.setSize(buildResources.get(fileName).available());
-                tOut.putArchiveEntry(entry);
-                IOUtils.copy(buildResources.get(fileName), tOut);
-                tOut.closeArchiveEntry();
+            if (buildResources != null) {
+            	// Put the rest of the resources in a flat dir
+                for (String fileName : buildResources.keySet()) {
+                    TarArchiveEntry entry = new TarArchiveEntry(fileName);
+                    entry.setSize(buildResources.get(fileName).available());
+                    tOut.putArchiveEntry(entry);
+                    IOUtils.copy(buildResources.get(fileName), tOut);
+                    tOut.closeArchiveEntry();
+                }
             }
-
+            
             tOut.flush();
             tOut.close();
 

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/IDockerImageBuilder.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/IDockerImageBuilder.java
@@ -7,6 +7,9 @@ import dev.galasa.docker.DockerManagerException;
 
 public interface IDockerImageBuilder {
 
+	public void buildImage(String imageName, InputStream Dockerfile) throws DockerManagerException;
+	
     public void buildImage(String imageName, InputStream Dockerfile, Map<String,InputStream> resources) throws DockerManagerException;
+    
     
 }

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/resources/resources/CommandBusyboxDockerfile
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/resources/resources/CommandBusyboxDockerfile
@@ -1,0 +1,3 @@
+FROM busybox:latest
+
+ENTRYPOINT [${COMMAND}] 


### PR DESCRIPTION
Docker volumes to offer to be able to chage both the file ownership and permission before mounting and starting the container.

Uses a busybox image to mount to the volume when the called to change permissions

Small other changes with how docker volumes produce the busybox image