### PR TITLE
Adding in prefix consideration for the image checks within user specified docker registries

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerEngineImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerEngineImpl.java
@@ -235,8 +235,9 @@ public class DockerEngineImpl implements IDockerEngine {
 				}
 				return response;
 			case HttpStatus.SC_NO_CONTENT:
-			case HttpStatus.SC_NOT_FOUND:
 				return null;
+			case HttpStatus.SC_NOT_FOUND:
+				throw new DockerNotFoundException("Docker API post returned 'not found': " + response.toString());
 			}
 
 			logger.error("Post failed to docker engine - " + resp.getStatusLine());

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerImageImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerImageImpl.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2020.
+ * Copyright contributors to the Galasa project
  */
 package dev.galasa.docker.internal;
 

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerImageImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerImageImpl.java
@@ -86,7 +86,7 @@ public class DockerImageImpl implements IDockerImage {
 		List<DockerRegistryImpl> registries = dockerManager.getRegistries();
 		for(DockerRegistryImpl registry : registries) {
 			if (registry.doYouHave(this)) {
-                this.fullName = registry.getHost() + "/" + workingName;
+                this.fullName = registry.getHost() + "/" + registry.getPrefix() + workingName;
                 this.authToken = registry.getAuthToken();
                 if (this.authToken != null) {
                     authRequired = true;

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
@@ -103,7 +103,7 @@ public class DockerRegistryImpl {
 		try {
 			registryAuthenticate(image);
 
-			String path = this.getPrefix() + "/v2/" + image.getImageName() + "/manifests/" + image.getTag();
+			String path = "/v2/" + getPrefix() + image.getImageName() + "/manifests/" + image.getTag();
 
 			HttpClientResponse<JsonObject> response = client.getJson(path);
 			if (response.getStatusCode() == (HttpStatus.SC_OK)) {
@@ -116,7 +116,7 @@ public class DockerRegistryImpl {
 			return false;
 		} catch (DockerManagerException e) {
 			logger.trace(e);
-			logger.error("Failed to access registry");
+			logger.warn("Failed to access registry");
 			return false;
 		} catch (ClassCastException e) {
 			logger.warn("Invalid JSON returned from Docker Registry\n" + resp, e);
@@ -245,7 +245,7 @@ public class DockerRegistryImpl {
 	 * @throws DockerManagerException
 	 */
 	private boolean retrieveRealm(DockerImageImpl image) throws DockerManagerException {
-		String path = "/v2/" + image.getImageName() + "/manifests/" + image.getTag();
+		String path = "/v2/" + getPrefix() + image.getImageName() + "/manifests/" + image.getTag();
 
 		try {
 			HttpClientResponse<JsonObject> response = this.client.getJson(path);

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2020.
+ * Copyright contributors to the Galasa project
  */
 package dev.galasa.docker.internal;
 
@@ -25,6 +23,7 @@ import dev.galasa.ICredentialsUsernamePassword;
 import dev.galasa.ICredentialsUsernameToken;
 import dev.galasa.docker.DockerManagerException;
 import dev.galasa.docker.internal.properties.DockerRegistryCredentials;
+import dev.galasa.docker.internal.properties.DockerRegistryPrefix;
 import dev.galasa.docker.internal.properties.DockerRegistryURL;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.IFramework;
@@ -45,6 +44,7 @@ public class DockerRegistryImpl {
 	private DockerManagerImpl 					dockerManager;
 	private URL 								registryUrl;
 	private String 								registryId;
+	private String 								prefix;
 
 	private ICredentialsService 				credService;
 
@@ -72,6 +72,7 @@ public class DockerRegistryImpl {
 		this.dockerManager = dockerManager;
 		this.registryId = registryId;
 		this.registryUrl = DockerRegistryURL.get(this);
+		this.prefix = DockerRegistryPrefix.get(this);
 
 		this.client = dockerManager.httpManager.newHttpClient();
 		this.realmClient = dockerManager.httpManager.newHttpClient();
@@ -330,6 +331,14 @@ public class DockerRegistryImpl {
 			return this.registryUrl.getHost();
         }
 	}   
+    
+    /**
+     * Returns the prefix of the registry
+     * @return String
+     */
+    public String getPrefix() {
+    	return this.prefix;
+    }
 	
 	/**
 	 * Returns the auth token

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
@@ -103,7 +103,7 @@ public class DockerRegistryImpl {
 		try {
 			registryAuthenticate(image);
 
-			String path = "/v2/" + image.getImageName() + "/manifests/" + image.getTag();
+			String path = this.getPrefix() + "/v2/" + image.getImageName() + "/manifests/" + image.getTag();
 
 			HttpClientResponse<JsonObject> response = client.getJson(path);
 			if (response.getStatusCode() == (HttpStatus.SC_OK)) {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/DockerRegistryImpl.java
@@ -23,7 +23,7 @@ import dev.galasa.ICredentialsUsernamePassword;
 import dev.galasa.ICredentialsUsernameToken;
 import dev.galasa.docker.DockerManagerException;
 import dev.galasa.docker.internal.properties.DockerRegistryCredentials;
-import dev.galasa.docker.internal.properties.DockerRegistryPrefix;
+import dev.galasa.docker.internal.properties.DockerImagePrefix;
 import dev.galasa.docker.internal.properties.DockerRegistryURL;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.IFramework;
@@ -72,7 +72,7 @@ public class DockerRegistryImpl {
 		this.dockerManager = dockerManager;
 		this.registryId = registryId;
 		this.registryUrl = DockerRegistryURL.get(this);
-		this.prefix = DockerRegistryPrefix.get(this);
+		this.prefix = DockerImagePrefix.get(this);
 
 		this.client = dockerManager.httpManager.newHttpClient();
 		this.realmClient = dockerManager.httpManager.newHttpClient();

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerImagePrefix.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerImagePrefix.java
@@ -13,7 +13,7 @@ import dev.galasa.framework.spi.cps.CpsProperties;
  * 
  * @galasa.cps.property
  * 
- * @galasa.name docker.registry.ID.prefix
+ * @galasa.name docker.registry.ID.image.prefix
  * 
  * @galasa.description Provides a prefix to be applied to all image names, particularly useful if you have a dockerhub proxy.
  * 
@@ -22,9 +22,9 @@ import dev.galasa.framework.spi.cps.CpsProperties;
  * @galasa.valid_values A valid String
  * 
  * @galasa.examples 
- * <code>docker.registry.LOCAL.prefix=dockerhub/</code>
+ * <code>docker.registry.LOCAL.image.prefix=dockerhub/</code>
  */
-public class DockerRegistryPrefix extends CpsProperties {
+public class DockerImagePrefix extends CpsProperties {
 
     public static String get(DockerRegistryImpl dockerRegistry) throws DockerManagerException {
         String id = dockerRegistry.getId();

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerImagePrefix.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerImagePrefix.java
@@ -9,7 +9,7 @@ import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.cps.CpsProperties;
 
 /**
- * Docker Registry Prefix CPS Property
+ * Docker Image Prefix CPS Property
  * 
  * @galasa.cps.property
  * 
@@ -28,16 +28,16 @@ public class DockerImagePrefix extends CpsProperties {
 
     public static String get(DockerRegistryImpl dockerRegistry) throws DockerManagerException {
         String id = dockerRegistry.getId();
-        String dockerRegistryPrefix = "";
+        String dockerImagePrefix = "";
         try {
-            dockerRegistryPrefix = getStringNulled(DockerPropertiesSingleton.cps(), "registry", "image.prefix", id);
+        	dockerImagePrefix = getStringNulled(DockerPropertiesSingleton.cps(), "registry", "image.prefix", id);
             // Default value
-            if (dockerRegistryPrefix == null) {
+            if (dockerImagePrefix == null) {
             	return "";
             }
-            return dockerRegistryPrefix + "/";
+            return dockerImagePrefix + "/";
         } catch (ConfigurationPropertyStoreException e) {
-            throw new DockerManagerException("Problem asking the CPS for the docker registry type", e);
+            throw new DockerManagerException("Problem asking the CPS for the docker image prefix", e);
         }
     }
 }

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryPrefix.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryPrefix.java
@@ -42,7 +42,7 @@ public class DockerRegistryPrefix extends CpsProperties {
             if (dockerRegistryPrefix == null) {
             	return "";
             }
-            return dockerRegistryPrefix;
+            return dockerRegistryPrefix + "/";
         } catch (ConfigurationPropertyStoreException e) {
             throw new DockerManagerException("Problem asking the CPS for the docker registry type", e);
         }

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryPrefix.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryPrefix.java
@@ -37,12 +37,12 @@ public class DockerRegistryPrefix extends CpsProperties {
         String id = dockerRegistry.getId();
         String dockerRegistryPrefix = "";
         try {
-            dockerRegistryPrefix = getStringNulled(DockerPropertiesSingleton.cps(), "registry", "prefix", "image", id);
+            dockerRegistryPrefix = getStringNulled(DockerPropertiesSingleton.cps(), "registry", "prefix", id, "image");
             // Default value
             if (dockerRegistryPrefix == null) {
             	return "";
             }
-            return dockerRegistryPrefix + "/";
+            return dockerRegistryPrefix;
         } catch (ConfigurationPropertyStoreException e) {
             throw new DockerManagerException("Problem asking the CPS for the docker registry type", e);
         }

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryPrefix.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryPrefix.java
@@ -15,21 +15,14 @@ import dev.galasa.framework.spi.cps.CpsProperties;
  * 
  * @galasa.name docker.registry.ID.prefix
  * 
- * @galasa.description Provides the prefix of a Docker Registry that is used by the Docker Manager.
+ * @galasa.description Provides a prefix to be applied to all image names, particularly useful if you have a dockerhub proxy.
  * 
- * @galasa.required Yes if the Registry ID is used in the CPS Property <code>docker.default.registries</code>.
- * 
- * @galasa.default None, except for DOCKERHUB where the default is <code>https://registry.hub.docker.com</code>
+ * @galasa.default None
  * 
  * @galasa.valid_values A valid String
  * 
  * @galasa.examples 
  * <code>docker.registry.LOCAL.prefix=dockerhub/</code>
- * 
- * @galasa.extra
- * If the Docker Registry requires credentials for authentication, then the id for the credentials must be provided using the CPS property 
- * <code>docker.registry.ID.credentials</code> or <code>docker.registry.credentials</code>
- * 
  */
 public class DockerRegistryPrefix extends CpsProperties {
 
@@ -37,7 +30,7 @@ public class DockerRegistryPrefix extends CpsProperties {
         String id = dockerRegistry.getId();
         String dockerRegistryPrefix = "";
         try {
-            dockerRegistryPrefix = getStringNulled(DockerPropertiesSingleton.cps(), "registry", "prefix", id, "image");
+            dockerRegistryPrefix = getStringNulled(DockerPropertiesSingleton.cps(), "registry", "image.prefix", id);
             // Default value
             if (dockerRegistryPrefix == null) {
             	return "";

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryPrefix.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/src/main/java/dev/galasa/docker/internal/properties/DockerRegistryPrefix.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.docker.internal.properties;
+
+import dev.galasa.docker.DockerManagerException;
+import dev.galasa.docker.internal.DockerRegistryImpl;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.cps.CpsProperties;
+
+/**
+ * Docker Registry Prefix CPS Property
+ * 
+ * @galasa.cps.property
+ * 
+ * @galasa.name docker.registry.ID.prefix
+ * 
+ * @galasa.description Provides the prefix of a Docker Registry that is used by the Docker Manager.
+ * 
+ * @galasa.required Yes if the Registry ID is used in the CPS Property <code>docker.default.registries</code>.
+ * 
+ * @galasa.default None, except for DOCKERHUB where the default is <code>https://registry.hub.docker.com</code>
+ * 
+ * @galasa.valid_values A valid String
+ * 
+ * @galasa.examples 
+ * <code>docker.registry.LOCAL.prefix=dockerhub/</code>
+ * 
+ * @galasa.extra
+ * If the Docker Registry requires credentials for authentication, then the id for the credentials must be provided using the CPS property 
+ * <code>docker.registry.ID.credentials</code> or <code>docker.registry.credentials</code>
+ * 
+ */
+public class DockerRegistryPrefix extends CpsProperties {
+
+    public static String get(DockerRegistryImpl dockerRegistry) throws DockerManagerException {
+        String id = dockerRegistry.getId();
+        String dockerRegistryPrefix = "";
+        try {
+            dockerRegistryPrefix = getStringNulled(DockerPropertiesSingleton.cps(), "registry", "prefix", "image", id);
+            // Default value
+            if (dockerRegistryPrefix == null) {
+            	return "";
+            }
+            return dockerRegistryPrefix;
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new DockerManagerException("Problem asking the CPS for the docker registry type", e);
+        }
+    }
+}


### PR DESCRIPTION
I have also added in a change I missed from [this](https://github.com/galasa-dev/managers/pull/711/files) PR for when docker API returns not found on a post request. 