### PR TITLE
Use a valid character for Windows path in archive name

### DIFF
--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/src/main/java/dev/galasa/mq/internal/MessageQueueImpl.java
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/src/main/java/dev/galasa/mq/internal/MessageQueueImpl.java
@@ -23,36 +23,37 @@ import org.apache.commons.logging.LogFactory;
 import dev.galasa.mq.IMessageQueue;
 
 public class MessageQueueImpl implements IMessageQueue {
-	
+
 	//Fields received from the constructor
 	private String queueName;
 	private MessageQueueManagerImpl qmgr;
 	private boolean archive;
 	private MQManagerImpl manager;
-	
+
 	private static String QUEUE_PROTOCOL = "queue:///";
 	private static String RAS_NAMESPACE = "mq";
 	private static String RAS_MESSAGING = "messages";
-	
+	private static String ARCHIVE_FILE_PREFIX = "message_";
+
 	//Generated Fields
 	private Destination destination;
 	private JMSConsumer consumer;
 	private JMSProducer producer;
-	
+
 	//Internal State
 	private boolean started = false;
 	private String currentMethod = new String();
 	private int numberOfMessagesLoggedInThisMethod = 1;
-	
+
 	private static final Log  logger = LogFactory.getLog(MessageQueueImpl.class);
-	
+
 	public MessageQueueImpl(String name, MessageQueueManagerImpl qmgr, boolean archive, MQManagerImpl manager) {
 		this.queueName = name;
 		this.qmgr = qmgr;
 		this.archive = archive;
 		this.manager = manager;
 	}
-	
+
 	/**
 	 * Starts the connection to the queue by obtaining the context from the qmgr
 	 * If we have already been started then just exit
@@ -98,23 +99,23 @@ public class MessageQueueImpl implements IMessageQueue {
 		archiveMessage(m, MessageDirection.INBOUND);
 		return m;
 	}
-	
+
 	@Override
 	public void clearQueue() {
 		while(consumer.receiveNoWait() != null) {}
 	}
-	
+
 	public String getName() {
 		return this.queueName;
 	}
-	
+
 	public MessageQueueManagerImpl getQmgr() {
 		return this.qmgr;
 	}
 	/**
-	 * If archival has been set in the annotation for this queue then 
+	 * If archival has been set in the annotation for this queue then
 	 * we archive this message in the RAS in the structure:
-	 * 
+	 *
 	 * mq
 	 * |
 	 * messages
@@ -125,13 +126,13 @@ public class MessageQueueImpl implements IMessageQueue {
 	 *           |
 	 *           ---<inbound/outbound>
 	 *               |
-	 *               ---message: <id>
+	 *               ---message_<id>
 	 * @param m the message we are archiving
 	 * @param direction the direction in which this message is traveling from the perspective of the test
 	 */
 	private void archiveMessage(Message m, MessageDirection direction) {
 		if(m == null || !archive)
-			return;		
+			return;
 		byte[] content;
 		try {
 			content = getContentOfMessage(m);
@@ -139,29 +140,29 @@ public class MessageQueueImpl implements IMessageQueue {
 			logger.warn("Unable to retrieve the content of a message while archiving");
 			return;
 		}
-		
+
 		Path folder = manager.getStoredArtifactRoot()
 							 .resolve(RAS_NAMESPACE)
 							 .resolve(RAS_MESSAGING)
 							 .resolve(getCurrentMethod())
 							 .resolve(this.queueName)
 							 .resolve(direction.toString().toLowerCase())
-							 .resolve("message:" + Integer.toString(numberOfMessagesLoggedInThisMethod));
+							 .resolve(ARCHIVE_FILE_PREFIX + Integer.toString(numberOfMessagesLoggedInThisMethod));
 		try {
 			Files.write(folder, content, StandardOpenOption.CREATE);
 		} catch (Exception e) {
 			logger.info("Unable to log message for a queue", e);
-		} 
+		}
 		this.numberOfMessagesLoggedInThisMethod++;
 	}
-	
+
 	private byte[] getContentOfMessage(Message m) throws JMSException {
 		byte[] content = new byte[0];
-		
+
 		if(m instanceof TextMessage) {
 			content = m.getBody(String.class).getBytes();
 		}
-		
+
 		if(m instanceof BytesMessage) {
 			BytesMessage bm = (BytesMessage)m;
 			bm.reset();
@@ -171,10 +172,10 @@ public class MessageQueueImpl implements IMessageQueue {
 		}
 		return content;
 	}
-	
+
 	/**
-	 * Internal check that the current method is the same as the 
-	 * method that we last checked  This allows us to create an index of the 
+	 * Internal check that the current method is the same as the
+	 * method that we last checked  This allows us to create an index of the
 	 * messages we have archived
 	 * @return
 	 */


### PR DESCRIPTION
Fixes #805 by using a `_` that is a valid character in Windows paths.

Note: My editor trims whitespace automatically (if that is an issue, I will switch it off).

Signed-off-by: Petr Plavjanik <petr.plavjanik@broadcom.com>