### PR TITLE
Bump DB2 manager up to v0.25.0 so it matches the release.yaml file content version.

### DIFF
--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa Db2 Manager'
 
-version = '0.24.0'
+version = '0.25.0'
 
 dependencies {
 	// implementation project(':galasa-managers-core-parent:dev.galasa.artifact.manager')


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- [x] Uplift the version in the `build.gradle` file to match the version in the `release.yaml`, so the OBR can be built properly.