### PR TITLE
uplift dependency onto 0.26.0 of framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Snap*.trc
 **/.gradle
 **/gradle/wrapper
 local-builds/
+**/.idea

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -160,27 +160,14 @@ else
     goals="build check publishToMavenLocal --parallel"
 fi
 
-cat << EOF 
-Using command:
-
-gradle \
+cmd="gradle  \
 ${CONSOLE_FLAG} \
 -Dorg.gradle.java.home=${JAVA_HOME} \
 -PsourceMaven=${SOURCE_MAVEN} ${OPTIONAL_DEBUG_FLAG} \
-${goals} \
-2>&1 > ${log_file}
+${goals} 
+"
 
-EOF
+$cmd 2>&1 > ${log_file}
 
-
-gradle \
-${CONSOLE_FLAG} \
--Dorg.gradle.java.home=${JAVA_HOME} \
--PsourceMaven=${SOURCE_MAVEN} ${OPTIONAL_DEBUG_FLAG} \
-${goals} \
-2>&1 > ${log_file}
-
-
-
-rc=$? ; if [[ "${rc}" != "0" ]]; then cat ${log_file} ; error "Failed to build ${project} see logs at ${log_file}" ; exit 1 ; fi
+rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to build ${project} see logs at ${log_file}" ; exit 1 ; fi
 success "Project ${project} built - OK - log is at ${log_file}"

--- a/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+++ b/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     api            'dev.galasa:dev.galasa:0.21.0'
-    implementation 'dev.galasa:dev.galasa.framework:0.25.0'
+    implementation 'dev.galasa:dev.galasa.framework:0.26.0'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'org.osgi:org.osgi.core:6.0.0'
     implementation 'org.osgi:org.osgi.service.component.annotations:1.3.0'


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>


Problem: can't build the managers code locally.

The managers code was depending upon v0.25.0 of the galasa framework component.

It should be depending upon 0.26.0 instead.

The dependency in the pom needs raising to the later level.

Have no idea why this didn't show up earlier... unless both versions are available to compile against.
