### PR TITLE
Add logging to Openstack Manager - Issue 1366

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
@@ -537,10 +537,12 @@ public class OpenstackHttpClient {
     protected String getImageId(@NotNull String image) throws OpenstackManagerException {
         try {
             checkToken();
+            logger.info("Openstack token is okay");
 
             // *** Retrieve a list of the images
-
-            HttpGet get = new HttpGet(this.openstackImageUri + "/v2/images");
+            String uri = this.openstackImageUri + "/v2/images";
+            logger.info("Attempting to get a list of the images from " + uri);
+            HttpGet get = new HttpGet(uri);
             get.addHeader(this.openstackToken.getHeader());
 
             try (CloseableHttpResponse response = httpClient.execute(get)) {
@@ -552,6 +554,7 @@ public class OpenstackHttpClient {
                 }
 
                 Images images = gson.fromJson(entity, Images.class);
+                logger.info(images);
                 if (images != null && images.images != null) {
                     for (Image i : images.images) {
                         if (i.name != null) {
@@ -562,6 +565,7 @@ public class OpenstackHttpClient {
                     }
                 }
             }
+            logger.info("No matching imageId found that matched " + image);
             return null;
         } catch (OpenstackManagerException e) {
             throw e;

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackLinuxImageImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackLinuxImageImpl.java
@@ -81,10 +81,14 @@ public class OpenstackLinuxImageImpl extends OpenstackServerImpl implements ILin
                 + this.tag);
 
         String flavor = LinuxFlavor.get(this.image);
+        logger.info("The Linux flavor is " + flavor);
+
+        String imageName = LinuxName.get(this.image);
+        logger.info("The image name is " + imageName);
 
         Server server = new Server();
         server.name = this.instanceName;
-        server.imageRef = getOpenstackHttpClient().getImageId(LinuxName.get(this.image));
+        server.imageRef = getOpenstackHttpClient().getImageId(imageName);
         server.flavorRef = getOpenstackHttpClient().getFlavourId(flavor);
         server.availability_zone = LinuxAvailablityZone.get(this.image);
         server.metadata = new GalasaMetadata();

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackManagerImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackManagerImpl.java
@@ -157,16 +157,18 @@ public class OpenstackManagerImpl extends AbstractManager implements ILinuxProvi
 
         // check we are enabled
         if (!OpenStackEnabled.get()) {
+            logger.info("OpenStack not enabled");
             return null;
         }
 
         // *** Check that we can connect to openstack before we attempt to provision, if
         // we can't end gracefully and give someone else a chance
         if (!openstackHttpClient.connectToOpenstack()) {
+            logger.info("Unable to connect to OpenStack");
             return null;
         }
 
-        // *** Locate the possible images that are available for selection
+        logger.info("Locating possible images that are available for selection");
         try {
             List<String> possibleImages = LinuxImages.get(operatingSystem, null);
 
@@ -174,21 +176,25 @@ public class OpenstackManagerImpl extends AbstractManager implements ILinuxProvi
             nextImage:
             while(possibleImagesIterator.hasNext()) {
                 String image = possibleImagesIterator.next();
+                logger.info("Checking if image " + image + " is correct for this test");
 
                 // First check to see the the tests MUST request a capability this server provides
                 List<String> availableCapabilities = LinuxImageCapabilities.get(image);
                 if (!availableCapabilities.isEmpty()) {
                     for(String availableCapability : availableCapabilities) {
+                        logger.info(availableCapability + " is an available capability of this image");
                         if (availableCapability.startsWith("+")) {
                             String actualAvailableCapability = availableCapability.substring(1);
                             boolean requestedCapability = false;
                             for(String choosenCapability : capabilities) {
                                 if (choosenCapability.equalsIgnoreCase(actualAvailableCapability)) {
+                                    logger.info("This image has an available capability " + actualAvailableCapability + " that matches a chosen capability " + choosenCapability);
                                     requestedCapability = true;
                                     break;
                                 }
                             }
                             if (!requestedCapability) {
+                                logger.info("This image had no availabilie capabilities that were chosen for this test");
                                 possibleImagesIterator.remove();
                                 continue nextImage;
                             }
@@ -209,12 +215,14 @@ public class OpenstackManagerImpl extends AbstractManager implements ILinuxProvi
                                 availableCapability = availableCapability.substring(1);
                             }
                             if (availableCapability.equalsIgnoreCase(choosenCapability)) {
+                                logger.info("This image has an available capability " + availableCapability + " that matches a required capability " + choosenCapability);
                                 found = true;
                                 break;
                             }
                         }
 
                         if (!found) {
+                            logger.info("This image had no available capabilities that we need so it is not possible to use");
                             possibleImagesIterator.remove();
                             continue nextImage;
                         }
@@ -231,6 +239,7 @@ public class OpenstackManagerImpl extends AbstractManager implements ILinuxProvi
 
             // *** Select the first image as they will be listed in preference order
             String selectedImage = possibleImages.get(0);
+            logger.info("The selected image for this test is " + selectedImage);
 
             // *** See if we have capacity for a new Instance on Openstack
             String instanceName = reserveInstance();


### PR DESCRIPTION
- Add logging to Openstack Manager to hopefully provide more information to debug Docker inttest failures
- Messages can be removed once defect is identified, or kept in if it doesn't clutter the log too much

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>