### PR TITLE
Update logging in OpenStack Manager again - Issue 1366

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
@@ -555,14 +555,17 @@ public class OpenstackHttpClient {
 
                 Images images = gson.fromJson(entity, Images.class);
                 if (images != null && images.images != null) {
-                    logger.info(images.toString());
                     for (Image i : images.images) {
                         if (i.name != null) {
+                            logger.info("Image name: " + i.name);
+                            logger.info("Image ID: " + i.id);
                             if (image.equals(i.name)) {
                                 return i.id;
                             }
                         }
                     }
+                } else {
+                    logger.info("No images returned from Openstack");
                 }
             }
             logger.info("No matching imageId found that matched " + image);


### PR DESCRIPTION
Images.toString once again just returned a reference. Have to try to print the fields of an Image object (if not null) to get anything useful.

Also added a message to log if Images is null and we are genuinely getting nothing back from OpenStack.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>