### PR TITLE
Search for specific image in Openstack and change logger messages to trace - Issue 1366

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
@@ -537,11 +537,11 @@ public class OpenstackHttpClient {
     protected String getImageId(@NotNull String image) throws OpenstackManagerException {
         try {
             checkToken();
-            logger.info("Openstack token is okay");
+            logger.trace("Openstack token is okay");
 
-            // *** Retrieve a list of the images
-            String uri = this.openstackImageUri + "/v2/images";
-            logger.info("Attempting to get a list of the images from " + uri);
+            // *** Attempt to retrieve the image we want from Openstack
+            String uri = this.openstackImageUri + "/v2/images?name=" + image;
+            logger.trace("Attempting to get the image " + image + " from " + uri);
             HttpGet get = new HttpGet(uri);
             get.addHeader(this.openstackToken.getHeader());
 
@@ -553,22 +553,18 @@ public class OpenstackHttpClient {
                     throw new OpenstackManagerException("OpenStack list image failed - " + status);
                 }
 
-                Images images = gson.fromJson(entity, Images.class);
-                if (images != null && images.images != null) {
-                    for (Image i : images.images) {
-                        if (i.name != null) {
-                            logger.info("Image name: " + i.name);
-                            logger.info("Image ID: " + i.id);
-                            if (image.equals(i.name)) {
-                                return i.id;
-                            }
+                Image openStackImage = gson.fromJson(entity, Image.class);
+                if (openStackImage != null) {
+                    if (openStackImage.name != null) {
+                        logger.trace("Image name: " + openStackImage.name);
+                        logger.trace("Image ID: " + openStackImage.id);
+                        if (image.equals(openStackImage.name)) {
+                            return openStackImage.id;
                         }
                     }
-                } else {
-                    logger.info("No images returned from Openstack");
                 }
             }
-            logger.info("No matching imageId found that matched " + image);
+            logger.trace("Image " + image + " wasn't found in Openstack");
             return null;
         } catch (OpenstackManagerException e) {
             throw e;

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackLinuxImageImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackLinuxImageImpl.java
@@ -81,10 +81,10 @@ public class OpenstackLinuxImageImpl extends OpenstackServerImpl implements ILin
                 + this.tag);
 
         String flavor = LinuxFlavor.get(this.image);
-        logger.info("The Linux flavor is " + flavor);
+        logger.trace("The Linux flavor is " + flavor);
 
         String imageName = LinuxName.get(this.image);
-        logger.info("The image name is " + imageName);
+        logger.trace("The image name is " + imageName);
 
         Server server = new Server();
         server.name = this.instanceName;

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackManagerImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackManagerImpl.java
@@ -157,18 +157,18 @@ public class OpenstackManagerImpl extends AbstractManager implements ILinuxProvi
 
         // check we are enabled
         if (!OpenStackEnabled.get()) {
-            logger.info("OpenStack not enabled");
+            logger.trace("OpenStack not enabled");
             return null;
         }
 
         // *** Check that we can connect to openstack before we attempt to provision, if
         // we can't end gracefully and give someone else a chance
         if (!openstackHttpClient.connectToOpenstack()) {
-            logger.info("Unable to connect to OpenStack");
+            logger.trace("Unable to connect to OpenStack");
             return null;
         }
 
-        logger.info("Locating possible images that are available for selection");
+        logger.trace("Locating possible images that are available for selection");
         try {
             List<String> possibleImages = LinuxImages.get(operatingSystem, null);
 
@@ -176,27 +176,27 @@ public class OpenstackManagerImpl extends AbstractManager implements ILinuxProvi
             nextImage:
             while(possibleImagesIterator.hasNext()) {
                 String image = possibleImagesIterator.next();
-                logger.info("Checking if image " + image + " is correct for this test");
+                logger.trace("Checking if image " + image + " is correct for this test");
 
                 // First check to see the the tests MUST request a capability this server provides
                 List<String> availableCapabilities = LinuxImageCapabilities.get(image);
                 if (!availableCapabilities.isEmpty()) {
                     for(String availableCapability : availableCapabilities) {
-                        logger.info(availableCapability + " is an available capability of this image");
+                        logger.trace(availableCapability + " is an available capability of this image");
                         if (availableCapability.startsWith("+")) {
                             String actualAvailableCapability = availableCapability.substring(1);
                             boolean requestedCapability = false;
                             for(String choosenCapability : capabilities) {
                                 if (choosenCapability.equalsIgnoreCase(actualAvailableCapability)) {
-                                    logger.info("This image has an available capability " + actualAvailableCapability + " that matches a chosen capability " + choosenCapability);
+                                    logger.trace("This image has an available capability " + actualAvailableCapability + " that matches a chosen capability " + choosenCapability);
                                     requestedCapability = true;
                                     break;
                                 } else {
-                                    logger.info("This image's available capability " + availableCapability + " is not required");
+                                    logger.trace("This image's available capability " + availableCapability + " is not required");
                                 }
                             }
                             if (!requestedCapability) {
-                                logger.info("This image had no availabilie capabilities that were chosen for this test");
+                                logger.trace("This image had no availabilie capabilities that were chosen for this test");
                                 possibleImagesIterator.remove();
                                 continue nextImage;
                             }
@@ -217,16 +217,16 @@ public class OpenstackManagerImpl extends AbstractManager implements ILinuxProvi
                                 availableCapability = availableCapability.substring(1);
                             }
                             if (availableCapability.equalsIgnoreCase(choosenCapability)) {
-                                logger.info("This image has an available capability " + availableCapability + " that matches a required capability " + choosenCapability);
+                                logger.trace("This image has an available capability " + availableCapability + " that matches a required capability " + choosenCapability);
                                 found = true;
                                 break;
                             } else {
-                                logger.info("This image's available capability " + availableCapability + " is not required");
+                                logger.trace("This image's available capability " + availableCapability + " is not required");
                             }
                         }
 
                         if (!found) {
-                            logger.info("This image had no available capabilities that we need so it is not possible to use");
+                            logger.trace("This image had no available capabilities that we need so it is not possible to use");
                             possibleImagesIterator.remove();
                             continue nextImage;
                         }
@@ -243,7 +243,7 @@ public class OpenstackManagerImpl extends AbstractManager implements ILinuxProvi
 
             // *** Select the first image as they will be listed in preference order
             String selectedImage = possibleImages.get(0);
-            logger.info("The selected image for this test is " + selectedImage);
+            logger.trace("The selected image for this test is " + selectedImage);
 
             // *** See if we have capacity for a new Instance on Openstack
             String instanceName = reserveInstance();


### PR DESCRIPTION
- Changed extra logging messages to trace as helpful to us but users might not want/need them
- Change the search in Openstack to look for the specific image we want instead of searching them all. Can either leave like this or once we have verified the image is there and visible to us, fix the pagination.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>