### PR TITLE
Openstack debugging - Issue 1366

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
@@ -553,6 +553,11 @@ public class OpenstackHttpClient {
                     throw new OpenstackManagerException("OpenStack list image failed - " + status);
                 }
 
+                logger.trace("Response code is " + status.getStatusCode());
+
+                logger.trace("Logging the entity in case the JSON deserialisation below is what fails");
+                logger.trace(entity);
+
                 Image openStackImage = gson.fromJson(entity, Image.class);
                 if (openStackImage != null) {
                     if (openStackImage.name != null) {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackLinuxImageImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackLinuxImageImpl.java
@@ -89,6 +89,15 @@ public class OpenstackLinuxImageImpl extends OpenstackServerImpl implements ILin
         Server server = new Server();
         server.name = this.instanceName;
         server.imageRef = getOpenstackHttpClient().getImageId(imageName);
+
+        /* REMOVE AFTER SEEING OUTPUT */
+        logger.trace("For debugging purposes, attempting to list a non-Snapshot image in Openstack to check our visibility");
+        String nonSnapshotImageImageRef = getOpenstackHttpClient().getImageId("lxc-ubuntu-16.04");
+        if (nonSnapshotImageImageRef != null && nonSnapshotImageImageRef != ""){
+            logger.trace("lxc-ubuntu-16.04 Image ID is: " + nonSnapshotImageImageRef);
+        }
+
+
         server.flavorRef = getOpenstackHttpClient().getFlavourId(flavor);
         server.availability_zone = LinuxAvailablityZone.get(this.image);
         server.metadata = new GalasaMetadata();


### PR DESCRIPTION
Previous PR adding name as a query parameter to the request still did not return the image we were looking for. However, I have added some more trace messages in case the JSON deserialisation just didn't work, as we should have thrown exception if we got anything but a 200 response code.

Also added a hard coded search for a non-Snapshot image as advised by James in case that makes a difference. This code block will need to be removed.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>