### PR TITLE
Add CPS property to select 3270 terminal outputs

### DIFF
--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/properties/TerminalOutput.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/properties/TerminalOutput.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.zos3270.internal.properties;
+
+import java.util.List;
+
+import dev.galasa.framework.spi.cps.CpsProperties;
+import dev.galasa.zos3270.Zos3270ManagerException;
+
+/**
+ * The 3270 terminal outputs to store in the RAS.
+ * </p>
+ * <p>
+ * The property is:<br>
+ * <br>
+ * zos3270.terminal.output=json,png
+ * </p>
+ * <p>
+ * The default is json.
+ * </p>
+ * 
+ *
+ */
+public class TerminalOutput extends CpsProperties {
+
+    public static List<String> get() throws Zos3270ManagerException {
+        return getStringListWithDefault(Zos3270PropertiesSingleton.cps(), "json", "terminal", "output");
+    }
+}


### PR DESCRIPTION
The new property is `zos3270.terminal.output`, which currently defaults to `json` and supports `json` and `png` values.