### PR TITLE
Add getCicsTerminals

### DIFF
--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa CICS/TS Manager'
 
-version = '0.26.0'
+version = '0.28.0'
 
 dependencies {
     api            project (':galasa-managers-zos-parent:dev.galasa.zos.manager')

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/internal/CicstsManagerImpl.java
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/internal/CicstsManagerImpl.java
@@ -448,4 +448,9 @@ public class CicstsManagerImpl extends AbstractManager implements ICicstsManager
 		}		
 		return clonedTaggedCicsRegions;
 	}
+
+	@Override
+	public List<ICicsTerminal> getCicsTerminals() {	
+		return new ArrayList<>(this.terminals);
+	}
 }

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/spi/ICicstsManagerSpi.java
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/src/main/java/dev/galasa/cicsts/spi/ICicstsManagerSpi.java
@@ -97,4 +97,6 @@ public interface ICicstsManagerSpi {
 	public Map<String, ICicsRegionProvisioned> getTaggedCicsRegions();
 
 	public ICicsRegion locateCicsRegion(String tag) throws CicstsManagerException;
+
+	public List<ICicsTerminal> getCicsTerminals();
 }

--- a/release.yaml
+++ b/release.yaml
@@ -29,7 +29,7 @@ managers:
     isolated: true
     
   - artifact: dev.galasa.cicsts.manager
-    version: 0.26.0
+    version: 0.28.0
     obr: true
     mvp: true
     javadoc: true


### PR DESCRIPTION
Signed-off-by: Mark Lawrence <15652599+Mark-J-Lawrence@users.noreply.github.com>

Adding a helper function for ability to get a list of all known CICS Terminals, required for the in-development DevSecOps manager.