### PR TITLE
refactor to make discard() easier to read, and avoid null pointer exceptions

### DIFF
--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/LocalEcosystemImpl.java
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/LocalEcosystemImpl.java
@@ -13,11 +13,13 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -462,136 +464,227 @@ public abstract class LocalEcosystemImpl extends AbstractEcosystemImpl implement
         this.localRuns.add(localRun);
     }
 
-    public void discard() {
-        
+
+    private void discardRunIdPrefix() {
         // Release runid prefix
-        
         try {
             this.runIdPrefix.discard();
         } catch (GalasaEcosystemManagerException e) {
             logger.warn("Failed to discard runid prefix from dss", e);
         }
+    }
 
-        // save all data in the stored artifacts
-
-        Path saRoot = getEcosystemManager().getFramework().getResultArchiveStore().getStoredArtifactsRoot();
-        Path saEcosystem = saRoot.resolve("ecosystem");
-
-        // CPS
+    private void saveArtifactFile(Path ecosystemRootFolderPath , Path sourceFilePath , String artifactName ) {
         try {
-            Files.copy(this.cpsFile, saEcosystem.resolve(cpsFile.getFileName().toString()));
+            Files.copy(cpsFile, ecosystemRootFolderPath.resolve(sourceFilePath.getFileName().toString()));
         } catch(Exception e) {
-            logger.warn("Failed to save the local ecosystem CPS",e);
+            logger.warn("Failed to save the local ecosystem "+artifactName,e);
         }
+    }
 
-        // DSS
+    private void saveArtifactFile(
+        Path targetRunFolderPath , 
+        String runName, 
+        Path sourceRasRunFolderPath , 
+        String artifactName ) {
+
         try {
-            Files.copy(this.dssFile, saEcosystem.resolve(dssFile.getFileName().toString()));
+            Path sourceFile = sourceRasRunFolderPath.resolve(artifactName);
+            if (Files.exists(sourceFile)) {
+                Files.copy(sourceFile, targetRunFolderPath.resolve(sourceFile.getFileName().toString()));
+            }
         } catch(Exception e) {
-            logger.warn("Failed to save the local ecosystem DSS",e);
+            logger.warn("Failed to copy run:" + runName + " artifact: "+artifactName,e);
         }
+    }
 
-        // overrides
-        try {
-            Files.copy(this.overridesFile, saEcosystem.resolve(overridesFile.getFileName().toString()));
-        } catch(Exception e) {
-            logger.warn("Failed to save the local ecosystem overrides",e);
-        }
-
-        // bootstrap
+    private void saveBootstrap(Path bootstrapFile, Path ecosystemRootFolderPath) {
         try {
             if (bootstrapFile == null) {
                 throw new Exception("Programming logic error: Bootstrap file is null.");
             }
+            
             Path bootstrapFilePath = bootstrapFile.getFileName();
             if (bootstrapFilePath==null) {
                 throw new Exception("Programming logic error: Bootstrap file path is null.");
             }
+
             String pathString = bootstrapFilePath.toString();
             logger.debug("Bootstrap file path : "+pathString);
 
-            if (saEcosystem == null) {
-                throw new Exception("Programming logic error: saEcosystem is null.");
-            }
-            Path ecosystemPath = saEcosystem.resolve(pathString);
+            if (ecosystemRootFolderPath == null) {
+                throw new Exception("Programming logic error: ecosystemRootFolderPath is null.");
+            } 
+
+            Path ecosystemPath = ecosystemRootFolderPath.resolve(pathString);
             if (ecosystemPath == null) {
                 throw new Exception("Programming logic error: ecosystemPath is null.");
             }
             logger.debug("ecosystemPath : "+pathString.toString());
 
-            Files.copy(this.bootstrapFile, ecosystemPath);
+            Files.copy(bootstrapFile, ecosystemPath);
+            
         } catch(Exception e) {
             logger.warn("Failed to save the local ecosystem bootstrap",e);
         }
+    }
 
-        logger.info("Not saving credentials into stored artifacts for security reasons");
+    public void discard() {
+        
+        discardRunIdPrefix();
 
-        // copy all the run data
-        for(LocalRun run : this.localRuns) {
-            String runName = run.getRunName();
+        // save all data in the stored artifacts
 
-            Path rasRun = this.rasDirectory.resolve(runName);
-            Path saRun = saEcosystem.resolve("runs").resolve(runName);
+        Path saRoot = getEcosystemManager().getFramework().getResultArchiveStore().getStoredArtifactsRoot();
+        Path ecosystemRootFolder = saRoot.resolve("ecosystem");
 
-            try {
-                Path runLog = rasRun.resolve("run.log");
-                if (Files.exists(runLog)) {
-                    Files.copy(runLog, saRun.resolve(runLog.getFileName().toString()));
-                }
-            } catch(Exception e) {
-                logger.warn("Failed to copy run " + runName + " run log",e);
+        if (ecosystemRootFolder == null) {
+            logger.warn("Failed to save the local ecosystem CPS,DSS,overrides: Programming logic error: ecosystemRootFolder is null.");
+        } else {
+            saveArtifactFile(cpsFile            , ecosystemRootFolder, "CPS");
+            saveArtifactFile(this.dssFile       , ecosystemRootFolder, "DSS");
+            saveArtifactFile(this.overridesFile , ecosystemRootFolder, "Overrides");
+            
+            saveBootstrap(bootstrapFile, ecosystemRootFolder);
+
+            logger.info("Not saving credentials into stored artifacts for security reasons");
+
+            saveRunsData( this.localRuns , this.rasDirectory, ecosystemRootFolder);
+        }
+    }
+
+    /**
+     * A data bean class which represents an artifact.
+     * 
+     * You can get these by reading an artifact metadata file.
+     */
+    public static class ArtifactDescriptor {
+        private String path ;
+        private String contentType ;
+
+        public ArtifactDescriptor(String path, String contentType) {
+            this.path = path ;
+            this.contentType = contentType;
+        }
+
+        public String getPath() {
+            return this.path;
+        }
+
+        public String getContentType() {
+            return this.contentType;
+        }
+
+        @Override
+        public String toString() {
+            String template = "path: ''{0}'' contentType: ''{1}''";
+            return MessageFormat.format(template,path,contentType);
+        }
+    }
+
+    /**
+     * The artifacts are described by a metadata file.
+     * 
+     * This is a properties file which has the form
+     * key=value
+     * 
+     * Where key is the path into the RAS folder of the artifact.
+     * And value is the content type used to create the folder
+     * in the target RAS folder.
+     * 
+     * Using this function to encapsulate the gathering of the artifact 
+     * descriptor information from that file, in case the file format changes.
+     * eg: To a json file which has more information inside.
+     * 
+     * Ideally, we would have an ArtifactMetadata object which housed the code which 
+     * does saving, and loading of the data...
+     * 
+     * @param sourceRasRunFolder
+     * @return A list of ArtifactDescriptor objects.
+     */
+    private List<ArtifactDescriptor> getArtifacts(Path sourceRasRunFolder) throws IOException {
+        Path artifactsMetadataFile = sourceRasRunFolder.resolve("artifacts.properties");
+        List<ArtifactDescriptor> artifacts = new ArrayList<ArtifactDescriptor>();
+        Properties artifactProperties = new Properties();
+        if (Files.exists(artifactsMetadataFile)) {
+            artifactProperties.load(Files.newInputStream(artifactsMetadataFile));
+
+            for(Entry<Object, Object> entry : artifactProperties.entrySet()) {
+                
+
+                String path = (String) entry.getKey();
+                String pathNoLeadingSlash = path.substring(1);
+
+                String contentType = (String) entry.getValue();
+                ArtifactDescriptor artifact = new ArtifactDescriptor(pathNoLeadingSlash, contentType);
+
+                artifacts.add(artifact);
             }
+        }
+        return artifacts ;
+    }
 
-            try {
-                Path structure = rasRun.resolve("structure.json");
-                if (Files.exists(structure)) {
-                    Files.copy(structure, saRun.resolve(structure.getFileName().toString()));
+    private void saveRunsData( List<LocalRun> localRuns , Path rasDirectory, Path ecosystemRootFolder ) {
+
+        if (ecosystemRootFolder == null) {
+            logger.warn("Failed to save the local run log, structure, artifacts.properties, all other artifacts...etc : Programming logic error: saEcosystem is null.");
+        } else {
+
+            // copy all the run data
+            for(LocalRun run : localRuns) {
+                String runName = run.getRunName();
+
+                Path rasRun = rasDirectory.resolve(runName);
+            
+                Path saRun = ecosystemRootFolder.resolve("runs").resolve(runName);
+                if (saRun==null) {
+                    logger.warn("Failed to save artifacts for run "+runName+": Program logic error: saRun is null.");
+                } else {
+                    // Save the framework files.
+                    saveArtifactFile(saRun, runName, rasRun, "run.log");
+                    saveArtifactFile(saRun, runName, rasRun, "structure.json");
+                    saveArtifactFile(saRun, runName, rasRun, "artifacts.properties");
+
+                    // Save the files that testcases/managers added.
+                    saveTestCaseArtifactFiles(saRun, runName, rasRun);
                 }
-            } catch(Exception e) {
-                logger.warn("Failed to copy run " + runName + " structure json",e);
             }
+        }
+    }
 
-            try {
-                Path artifacts = rasRun.resolve("artifacts.properties");
-                if (Files.exists(artifacts)) {
-                    Files.copy(artifacts, saRun.resolve(artifacts.getFileName().toString()));
-                }
-            } catch(Exception e) {
-                logger.warn("Failed to copy run " + runName + " artifacts properties",e);
-            }
+    private void saveTestCaseArtifactFiles(Path saRun, String runName, Path rasRun) {
+        try {
+            Path artifactsDirectory = rasRun.resolve("artifacts");
 
+            // Don't bother going further if there is no artifacts folder
+            // where testcase-generated artifacts get stored.
+            if( Files.exists(artifactsDirectory) ) {
 
-            try {
-                Properties artifacts = new Properties();
-                Path artifactsFile = rasRun.resolve("artifacts.properties");
-                Path artifactsDirectory = rasRun.resolve("artifacts");
-                if (Files.exists(artifactsFile) && Files.exists(artifactsDirectory)) {
-                    artifacts.load(Files.newInputStream(artifactsFile));
+                List<ArtifactDescriptor> artifacts = getArtifacts(rasRun);
+                for( ArtifactDescriptor artifactDescriptor : artifacts ) {
 
-                    for(Entry<Object, Object> entry : artifacts.entrySet()) {
-                        String key = (String) entry.getKey();
-                        String value = (String) entry.getValue();
+                    try {
+                        String artifactPath = artifactDescriptor.getPath();
+                        String contentType = artifactDescriptor.getContentType();
+                        
+                        Path sourceArtifactPath = saRun.resolve(artifactPath);
+                        Files.createDirectories(sourceArtifactPath.getParent());
 
-                        try {
-                            String artifactPath = key.substring(1);
+                        Path rasArtifact = artifactsDirectory.resolve(artifactPath);
+                        ResultArchiveStoreContentType type = new ResultArchiveStoreContentType(contentType);
 
-                            Path saArtifact = saRun.resolve(artifactPath);
-                            Files.createDirectories(saArtifact.getParent());
-                            Path rasArtifact = artifactsDirectory.resolve(artifactPath);
-                            ResultArchiveStoreContentType type = new ResultArchiveStoreContentType(value);
-
-                            try (InputStream is = Files.newInputStream(rasArtifact); 
-                                    OutputStream os = Files.newOutputStream(saArtifact, StandardOpenOption.CREATE_NEW, new SetContentType(type))) {
-                                IOUtils.copy(is, os);
-                            }
-                        } catch(Exception e) {
-                            logger.warn("Failed to copy run " + runName + " artifact " + key,e);
+                        try (InputStream is = Files.newInputStream(rasArtifact); 
+                            OutputStream os = Files.newOutputStream(sourceArtifactPath, StandardOpenOption.CREATE_NEW, new SetContentType(type))) {
+                            IOUtils.copy(is, os);
                         }
+
+                    } catch(Exception e) {
+                        logger.warn("Failed to copy run " + runName + " artifact " + artifactDescriptor,e);
                     }
                 }
-            } catch(Exception e) {
-                logger.warn("Failed to copy run " + runName + " artifacts",e);
             }
+        } catch(Exception e) {
+            logger.warn("Failed to copy run " + runName + " artifacts",e);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

For some reason, the ecosystem root folder path is null. This causes cleanup after a failure cases to throw null pointer exceptions.

While trying to avoid the extra noise of the NPEs, I refactored the code to make methods shorter, and remove duplicate program elements.

The diff in github isn't great.
