### PR TITLE
Import missing packages

### DIFF
--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/bnd.bnd
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/bnd.bnd
@@ -3,5 +3,7 @@ Bundle-Name: Galasa zOS 3270 Terminal Manager - Common Packages
 Export-Package: dev.galasa.zos3270.common.screens,\
     dev.galasa.zos3270.common.screens.images,\
     dev.galasa.zos3270.common.screens.json
-Import-Package: javax.validation.constraints;resolution:=optional
+Import-Package: javax.validation.constraints;resolution:=optional,\
+    javax.imageio,\
+    dev.galasa.framework.spi
 


### PR DESCRIPTION
Regression tests that should generate 3270 images are encountering the error shown below. This change imports the missing packages into the OSGi bundle for the zos3270.common package, resolving the error.
```
java.lang.NoClassDefFoundError: dev/galasa/framework/spi/IConfidentialTextService
	at dev.galasa.zos3270.common.screens.images.TerminalImageTransform.renderTerminalImage(TerminalImageTransform.java:110)
	at dev.galasa.zos3270.common.screens.images.TerminalImageTransform.writeImage(TerminalImageTransform.java:81)
	at dev.galasa.zos3270.spi.Zos3270TerminalImpl.writeImageToDisk(Zos3270TerminalImpl.java:339)
	at dev.galasa.zos3270.spi.Zos3270TerminalImpl.writeTerminalImages(Zos3270TerminalImpl.java:322)
	at dev.galasa.zos3270.spi.Zos3270TerminalImpl.writeRasOutput(Zos3270TerminalImpl.java:282)
	at dev.galasa.zos3270.spi.Zos3270TerminalImpl.screenUpdated(Zos3270TerminalImpl.java:223)
	at dev.galasa.zos3270.spi.Screen.aid(Screen.java:1827)
	at dev.galasa.zos3270.spi.Terminal.clear(Terminal.java:381)
	at dev.galasa.cicsts.ceda.internal.CedaImpl.createResource(CedaImpl.java:72)
	at dev.galasa.inttests.ceci.AbstractCECILocal.loadResources(AbstractCECILocal.java:54)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at dev.galasa.framework.GenericMethodWrapper.invoke(GenericMethodWrapper.java:86)
	at dev.galasa.framework.TestClassWrapper.runTestMethods(TestClassWrapper.java:192)
	at dev.galasa.framework.TestRunner.runTestClassWrapper(TestRunner.java:548)
	at dev.galasa.framework.TestRunner.runEnvironment(TestRunner.java:520)
	at dev.galasa.framework.TestRunner.createEnvironment(TestRunner.java:480)
	at dev.galasa.framework.TestRunner.generateEnvironment(TestRunner.java:450)
	at dev.galasa.framework.TestRunner.runTest(TestRunner.java:368)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at dev.galasa.boot.felix.FelixFramework.runTest(FelixFramework.java:235)
	at dev.galasa.boot.Launcher.launch(Launcher.java:168)
	at dev.galasa.boot.Launcher.main(Launcher.java:122)
```