### PR TITLE
fix CEDA helper timing issues + typos

### DIFF
--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa CICS/TS CEDA Manager'
 
-version = '0.21.0'
+version = '0.22.0'
 
 dependencies {
     api            project (':galasa-managers-cicsts-parent:dev.galasa.cicsts.manager')

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa CICS/TS CEDA Manager'
 
-version = '0.22.0'
+version = '0.29.0'
 
 dependencies {
     api            project (':galasa-managers-cicsts-parent:dev.galasa.cicsts.manager')

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/src/main/java/dev/galasa/cicsts/ceda/internal/CedaImpl.java
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/src/main/java/dev/galasa/cicsts/ceda/internal/CedaImpl.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2020-2021.
+ * Copyright contributors to the Galasa project
  */
 package dev.galasa.cicsts.ceda.internal;
 
@@ -46,11 +44,11 @@ public class CedaImpl implements ICeda{
 		try {
 			if(resourceParameters==null){
 				terminal.type("CEDA DEFINE " + resourceType + "(" + resourceName +
-						") GROUP(" + groupName + ") ").enter().waitForKeyboard();
+						") GROUP(" + groupName + ") ").enter().wfk();
 			}else{
 
 				terminal.type("CEDA DEFINE " + resourceType + "(" + resourceName +
-						") GROUP(" + groupName + ") " + resourceParameters).enter().waitForKeyboard();
+						") GROUP(" + groupName + ") " + resourceParameters).enter().wfk();
 			}
 		}catch(TimeoutException | KeyboardLockedException | NetworkException | TerminalInterruptedException | FieldNotFoundException e) {
 			throw new CedaException("Problem with starting the CEDA transaction", e);
@@ -59,7 +57,7 @@ public class CedaImpl implements ICeda{
 		try {
 			if(terminal.retrieveScreen().contains("DEFINE SUCCESSFUL")){
 				if(terminal.retrieveScreen().contains("MESSAGES:")) {
-					terminal.pf9();
+					terminal.pf9().wfk();
 				}
 			}
 		}catch (Exception e) {
@@ -67,10 +65,8 @@ public class CedaImpl implements ICeda{
 		}
 
 		try {
-			terminal.pf3();
-			terminal.waitForKeyboard();
-			terminal.clear();
-			terminal.waitForKeyboard();
+			terminal.pf3().wfk();
+			terminal.clear().wfk();
 		}catch(Exception e) {
 			throw new CedaException("Unable to return terminal back into reset state", e);
 		}
@@ -92,7 +88,7 @@ public class CedaImpl implements ICeda{
         }
 
 		try {
-			terminal.type("CEDA INSTALL GROUP(" + groupName + ")").enter().waitForKeyboard();
+			terminal.type("CEDA INSTALL GROUP(" + groupName + ")").enter().wfk();
 
 		}catch(Exception e) {
 			throw new CedaException("Problem with starting the CEDA transaction");
@@ -100,10 +96,9 @@ public class CedaImpl implements ICeda{
 
 		try {
 			if(!terminal.retrieveScreen().contains("INSTALL SUCCESSFUL")) {
-				terminal.pf9();
-				terminal.pf3();
-				terminal.clear();
-				terminal.waitForKeyboard();
+				terminal.pf9().wfk();
+				terminal.pf3().wfk();
+				terminal.clear().wfk();
 				throw new CedaException("Errors detected whilst installing group");
 			}
 		}catch(Exception e) {
@@ -111,10 +106,8 @@ public class CedaImpl implements ICeda{
 		}
 
 		try {
-			terminal.pf3();
-			terminal.waitForKeyboard();
-			terminal.clear();
-			terminal.waitForKeyboard();
+			terminal.pf3().wfk();
+			terminal.clear().wfk();
 		}catch(Exception e) {
 			throw new CedaException("Unable to return terminal back into reset state", e);
 		}
@@ -140,7 +133,7 @@ public class CedaImpl implements ICeda{
 		try {
 
 			terminal.type("CEDA INSTALL " + resourceType + "(" + resourceName + ") GROUP(" +
-					cedaGroup + ")").enter().waitForKeyboard();
+					cedaGroup + ")").enter().wfk();
 
 		}catch(Exception e) {
 			throw new CedaException("Problem with starting the CEDA transaction", e);
@@ -159,8 +152,7 @@ public class CedaImpl implements ICeda{
 				}
 
 				if(error) {
-					terminal.pf9();
-					terminal.waitForKeyboard();
+					terminal.pf9().wfk();
 					throw new CedaException("Errors detected whilst installing group");
 				}
 			}catch(Exception e) {
@@ -171,10 +163,8 @@ public class CedaImpl implements ICeda{
 		}
 
 		try {
-			terminal.pf3();
-			terminal.waitForKeyboard();
-			terminal.clear();
-			terminal.waitForKeyboard();
+			terminal.pf3().wfk();
+			terminal.clear().wfk();
 		}catch(Exception e) {
 			throw new CedaException("Unable to return terminal back into reset state", e);
 		}
@@ -196,17 +186,16 @@ public class CedaImpl implements ICeda{
         }
 
 		try {
-			terminal.type("CEDA DELETE GROUP(" + groupName + ") ALL").enter().waitForKeyboard();
+			terminal.type("CEDA DELETE GROUP(" + groupName + ") ALL").enter().wfk();
 		}catch(Exception e) {
 			throw new CedaException("Problem with starting the CEDA transaction");
 		}
 
 		try {
 			if(!terminal.retrieveScreen().contains("DELETE SUCCESSFUL")) {
-				terminal.pf9();
-				terminal.pf3();
-				terminal.clear();
-				terminal.waitForKeyboard();
+				terminal.pf9().wfk();
+				terminal.pf3().wfk();
+				terminal.clear().wfk();
 
 				throw new CedaException("Errors detected whilst discarding group");
 			}
@@ -215,10 +204,8 @@ public class CedaImpl implements ICeda{
 		}
 
 		try {
-			terminal.pf3();
-			terminal.waitForKeyboard();
-			terminal.clear();
-			terminal.waitForKeyboard();
+			terminal.pf3().wfk();
+			terminal.clear().wfk();
 		}catch(Exception e) {
 			throw new CedaException("Unable to return terminal back into reset state", e);
 		}
@@ -244,30 +231,27 @@ public class CedaImpl implements ICeda{
 
 		try {
 
-			terminal.waitForKeyboard();
+			terminal.wfk();
 			terminal.type("CEDA DELETE " + resourceType + "("
-					+ resourceName + ") GROUP(" + groupName + ")").enter();
-			terminal.waitForKeyboard();
+					+ resourceName + ") GROUP(" + groupName + ")").enter().wfk();
 		}catch(Exception e) {
 			throw new CedaException("Problem with starting the CEDA transaction", e);
 		}
 
 		try {
 			if(!terminal.retrieveScreen().contains("DELETE SUCCESSFUL")) {
-				terminal.pf9()
-				.pf3().clear()
-				.waitForKeyboard();
+				terminal.pf9().wfk();
+				terminal.pf3().wfk();
+        terminal.clear().wfk();
 				throw new CedaException("Errors detected whilst discarding group");
 			}
 		}catch(Exception e) {
-			throw new CedaException("Problem determinign the result from the CEDA command)", e);
+			throw new CedaException("Problem determining the result from the CEDA command)", e);
 
 		}
 		try {
-			terminal.pf3();
-			terminal.waitForKeyboard();
-			terminal.clear();
-			terminal.waitForKeyboard();
+			terminal.pf3().wfk();
+			terminal.clear().wfk();
 		}catch(Exception e) {
 			throw new CedaException("Unable to return terminal back into reset state", e);
 		}
@@ -291,9 +275,8 @@ public class CedaImpl implements ICeda{
 
 
 		try {
-			terminal.waitForKeyboard();
-			terminal.type("CEDA DISPLAY " + resourceType + "(" + resourceName + ") GROUP(" + groupName + ")").enter();
-			terminal.waitForKeyboard();
+			terminal.wfk();
+			terminal.type("CEDA DISPLAY " + resourceType + "(" + resourceName + ") GROUP(" + groupName + ")").enter().wfk();
 		} catch(Exception e) {
 			throw new CedaException("Problem with starting the CEDA transaction", e);
 		}
@@ -303,18 +286,18 @@ public class CedaImpl implements ICeda{
 			if (terminal.retrieveScreen().contains("RESULTS: 1 TO 1 OF 1"))	{
 				exists = true;
 			} else if (!terminal.retrieveScreen().contains("DISPLAY UNSUCCESSFUL")) {
-				terminal.pf9().pf3().clear().waitForKeyboard();
+				terminal.pf9().wfk();
+        terminal.pf3().wfk();
+        terminal.clear().wfk();
 				throw new CedaException("Errors detected whilst displaying resource");
 			}
 		} catch(Exception e) {
-			throw new CedaException("Problem determinign the result from the CEDA command)", e);
+			throw new CedaException("Problem determining the result from the CEDA command)", e);
 
 		}
 		try {
-			terminal.pf3();
-			terminal.waitForKeyboard();
-			terminal.clear();
-			terminal.waitForKeyboard();
+			terminal.pf3().wfk();
+			terminal.clear().wfk();
 		} catch(Exception e) {
 			throw new CedaException("Unable to return terminal back into reset state", e);
 		}

--- a/release.yaml
+++ b/release.yaml
@@ -61,7 +61,7 @@ managers:
     isolated: true
     
   - artifact: dev.galasa.cicsts.ceda.manager
-    version: 0.22.0
+    version: 0.29.0
     obr: true
     mvp: true
     javadoc: true

--- a/release.yaml
+++ b/release.yaml
@@ -61,7 +61,7 @@ managers:
     isolated: true
     
   - artifact: dev.galasa.cicsts.ceda.manager
-    version: 0.21.0
+    version: 0.22.0
     obr: true
     mvp: true
     javadoc: true


### PR DESCRIPTION
I've been experiencing a persistent problem whilst developing the SDV manager where 50% of runs would fail, I decided to have a dig into it today.

I'm probably doing something considered bad practice, but either way, Galasa shouldn't break doing it:

```
try {
     region.ceda().deleteGroup(terminal, "SRRGRP");
} catch (CedaException e) {}
			
region.ceda().createResource(terminal, "JOURNALMODEL", "SRR", "SRRGRP", "JOURNALNAME(DFHSECR) DESCRIPTION(SRR JOURNAL) TYPE(MVS) STREAMNAME(MLAWR." + region.getApplid() + ".DFHSECR)");
region.ceda().installGroup(terminal, "SRRGRP");
```

Depending on the scenario, the `SRRGRP` may or may not exist when running this code. If it does exist, then things behave, if it doesn't, it causes a `DELETE UNSUCCESSFUL` message, which causes a different code path to be taken in the CEDA helper.
I found that when debugging, everything worked fine, it would only fail when letting the code blitz though, the `createResource` function would fail trying to reset the screen, it would go round in a loop and never set `foundNative` to `true`, likely as the screen wasn't in an expected state from the rushed existing out of `deleteGroup()` . It whiffed of a timing issue.

Looking at the code, there were function key presses one after another, without waiting in-between to check the terminal was ready for the next input, I dropped in a `wfk()` and everything started working reliably.

I found there were a few places in the CEDA helper than needed this, plus it was a bit messy with lots of switching between the use of `wfk()` and `waitForKeyboard()`, so I've standardised it throughout and made it a bit clearer. I also fixed two typos.

Let me know if these widespread changes aren't suitable & I'll reduce to just the fix that stops my code breaking.
I've tested my code path thoroughly now though, and its resolved.
