### PR TITLE
re-build release.yaml from the managers in the source tree.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Snap*.trc
 **/gradle/wrapper
 local-builds/
 **/.idea
+temp/

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ This code is under the [Eclipse Public License 2.0](https://github.com/galasa-de
 Use the `./build-locally.sh` script to build locally.
 
 ## Updating the versions of things
-Use the `./set-version.sh --version x.y.z`, where `x.y.z` is the version you want things to be.
-That script also scans the contents of the managers and populates the `release.yaml` file with version information 
-taken from each manager source folder.
+Use the `./build-release-yaml.sh` script to scan the contents of the managers source code and populate the `release.yaml` file with version information taken from each manager source folder.
 
 
 

--- a/README.md
+++ b/README.md
@@ -26,4 +26,13 @@ Other Galasa repositories are available on [GitHub](https://github.com/galasa-de
 
 This code is under the [Eclipse Public License 2.0](https://github.com/galasa-dev/maven/blob/main/LICENSE).
 
+## Building locally
+Use the `./build-locally.sh` script to build locally.
+
+## Updating the versions of things
+Use the `./set-version.sh --version x.y.z`, where `x.y.z` is the version you want things to be.
+That script also scans the contents of the managers and populates the `release.yaml` file with version information 
+taken from each manager source folder.
+
+
 

--- a/build-release-yaml.sh
+++ b/build-release-yaml.sh
@@ -2,7 +2,7 @@
 
 #-----------------------------------------------------------------------------------------                   
 #
-# Objectives: Sets the version number, and/or re-build the release.yaml
+# Objectives: Re-build the release.yaml
 #
 # Environment variable over-rides:
 # None
@@ -65,24 +65,18 @@ note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" 
 function usage {
     h1 "Syntax"
     cat << EOF
-set-version.sh [OPTIONS]
+build-release-yaml.sh [OPTIONS]
 Options are:
--v | --version xxx : Mandatory. Set the version number to something explicitly. 
-    Re-builds the release.yaml based on the contents of sub-projects.
-    For example '--version 0.29.0'
+(none yet implemented)
 EOF
 }
 
 #-----------------------------------------------------------------------------------------                   
 # Process parameters
 #-----------------------------------------------------------------------------------------                   
-overall_version=""
 
 while [ "$1" != "" ]; do
     case $1 in
-        -v | --version )        export overall_version=$1
-                                shift
-                                ;;
         -h | --help )           usage
                                 exit
                                 ;;
@@ -93,15 +87,9 @@ while [ "$1" != "" ]; do
     shift
 done
 
-if [[ -z $overall_version ]]; then 
-    error "Missing mandatory '--version' argument."
-    usage
-    exit 1
-fi
 
 function build_release_yaml {
     target_file=$1
-
 
     cd $BASEDIR
 

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cicsts.ceci.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/settings.gradle
@@ -1,1 +1,6 @@
 rootProject.name = 'dev.galasa.cicsts.ceci.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_bom = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.cicsts.ceci.manager'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cicsts.ceci.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_javadoc = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cicsts.ceda.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.cicsts.ceda.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.cicsts.ceda.manager'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceda.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cicsts.ceda.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_javadoc = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cicsts.cemt.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.cicsts.cemt.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.cicsts.cemt.manager'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.cemt.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cicsts.cemt.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_javadoc = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/settings.gradle
@@ -1,1 +1,6 @@
 rootProject.name = 'dev.galasa.cicsts.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_bom = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cicsts.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.cicsts.manager'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cicsts.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_javadoc = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.resource.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.resource.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cicsts.resource.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.resource.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.resource.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.cicsts.resource.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.cloud.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.cloud.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.cloud.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.cloud.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.cloud.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.cloud.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.docker.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.docker.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.docker.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.docker.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.docker.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/settings.gradle
@@ -1,1 +1,4 @@
 rootProject.name = 'dev.galasa.kubernetes.manager.ivt'
+
+include_in_obr = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager.ivt/settings.gradle
@@ -1,4 +1,9 @@
 rootProject.name = 'dev.galasa.kubernetes.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.kubernetes.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.kubernetes.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.kubernetes.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.liberty.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_javadoc = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.liberty.manager'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.openstack.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.openstack.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-common-parent/dev.galasa.common/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-common-parent/dev.galasa.common/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.common'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-common-parent/dev.galasa.common/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-common-parent/dev.galasa.common/settings.gradle
@@ -1,1 +1,6 @@
 rootProject.name = 'dev.galasa.common'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.http.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.http.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.http.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.http.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.ipnetwork.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.ipnetwork.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.mq.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.mq.manager.ivt'
+
+include_in_obr = true
+include_in_bom = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.mq.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.mq.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.artifact.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.artifact.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.artifact.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_code_coverage = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.artifact.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.artifact.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.core.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.core.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.core.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.core.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.core.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.textscan.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.textscan.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.textscan.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.textscan.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-core-parent/dev.galasa.textscan.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.textscan.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.db2.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.db2.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.db2.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.db2.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.java.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.java.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.java.ubuntu.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.ubuntu.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.java.ubuntu.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.java.windows.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-languages-parent/dev.galasa.java.windows.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.java.windows.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager.ivt/settings.gradle
@@ -1,1 +1,4 @@
 rootProject.name = 'dev.galasa.elasticlog.manager.ivt'
+
+include_in_obr = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager.ivt/settings.gradle
@@ -1,4 +1,9 @@
 rootProject.name = 'dev.galasa.elasticlog.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.elasticlog.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/settings.gradle
@@ -1,1 +1,6 @@
 rootProject.name = 'dev.galasa.elasticlog.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.phoenix2.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.phoenix2.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.phoenix2.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.phoenix2.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.phoenix2.manager/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.phoenix2.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager.ivt/settings.gradle
@@ -1,1 +1,6 @@
-rootProject.name = 'dev.galasa.galasaecosystem.manager'
+rootProject.name = 'dev.galasa.galasaecosystem.manager.ivt'
+
+include_in_obr = true
+include_in_isolated = true
+
+    

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.galasaecosystem.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_isolated = true
 

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.galasaecosystem.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/settings.gradle
@@ -1,1 +1,6 @@
 rootProject.name = 'dev.galasa.galasaecosystem.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.jmeter.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager.ivt/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.jmeter.manager.ivt'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.jmeter.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.jmeter.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.selenium.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.selenium.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.selenium.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.selenium.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.selenium.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.vtp.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.vtp.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.vtp.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.vtp.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.vtp.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.vtp.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager.ivt/settings.gradle
@@ -1,4 +1,9 @@
 rootProject.name = 'dev.galasa.linux.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager.ivt/settings.gradle
@@ -1,1 +1,4 @@
 rootProject.name = 'dev.galasa.linux.manager.ivt'
+
+include_in_obr = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.linux.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.linux.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-windows-parent/dev.galasa.windows.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-windows-parent/dev.galasa.windows.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.windows.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-windows-parent/dev.galasa.windows.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-windows-parent/dev.galasa.windows.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.windows.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-workflow-parent/dev.galasa.githubissue.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-workflow-parent/dev.galasa.githubissue.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.githubissue.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+

--- a/galasa-managers-parent/galasa-managers-workflow-parent/dev.galasa.githubissue.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-workflow-parent/dev.galasa.githubissue.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.githubissue.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zos.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.zos.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.zos.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zos.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/settings.gradle
@@ -1,2 +1,7 @@
 rootProject.name = 'dev.galasa.zos3270.common'
 
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zos3270.common'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'dev.galasa.zos3270.manager.ivt'
+
+include_in_obr = true
+include_in_mvp = true
+include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager.ivt/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zos3270.manager.ivt'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_mvp = true
 include_in_isolated = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zos3270.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.zos3270.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.zosbatch.rseapi.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosbatch.rseapi.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosbatch.zosmf.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.zosbatch.zosmf.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.oeconsol.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.oeconsol.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosconsole.oeconsol.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.oeconsol.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.oeconsol.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.zosconsole.oeconsol.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.zosmf.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.zosmf.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.zosconsole.zosmf.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.zosmf.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.zosmf.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosconsole.zosmf.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.rseapi.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.rseapi.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.zosfile.rseapi.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.rseapi.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.rseapi.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosfile.rseapi.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.zosmf.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.zosmf.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosfile.zosmf.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.zosmf.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.zosmf.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.zosfile.zosmf.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.angel.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.angel.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.zosliberty.angel.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.angel.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.angel.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosliberty.angel.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.zosliberty.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosliberty.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosliberty.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosmf.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosmf.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.zosmf.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosmf.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosmf.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosmf.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosprogram.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosprogram.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.zosprogram.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosprogram.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosprogram.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosprogram.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosrseapi.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosrseapi.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.zosrseapi.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zossecurity.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zossecurity.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zossecurity.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_javadoc = true
 include_in_bom = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zossecurity.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zossecurity.manager/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'dev.galasa.zossecurity.manager'
+
+include_in_obr = true
+include_in_javadoc = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zostsocommand.ssh.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zostsocommand.ssh.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.zostsocommand.ssh.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zostsocommand.ssh.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zostsocommand.ssh.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zostsocommand.ssh.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosunixcommand.ssh.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosunixcommand.ssh.manager/settings.gradle
@@ -1,5 +1,10 @@
 rootProject.name = 'dev.galasa.zosunixcommand.ssh.manager'
 
+// Note: These values are consumed by the build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 include_in_obr = true
 include_in_bom = true
 include_in_mvp = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosunixcommand.ssh.manager/settings.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosunixcommand.ssh.manager/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'dev.galasa.zosunixcommand.ssh.manager'
+
+include_in_obr = true
+include_in_bom = true
+include_in_mvp = true
+include_in_isolated = true
+include_in_codecoverage = true

--- a/release.yaml
+++ b/release.yaml
@@ -1,6 +1,16 @@
 #
 # Copyright contributors to the Galasa project 
 #
+
+# -----------------------------------------------------------
+#
+#                         WARNING
+#
+# This file is periodically re-generated from the contents of 
+# the repository, so don't make changes here manually please.
+# -----------------------------------------------------------
+
+
 apiVersion: galasa.dev/v1alpha
 kind: Release
 metadata:
@@ -13,83 +23,67 @@ managers:
 # Manager 
 #  
 
-  - artifact: dev.galasa.artifact.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.artifact.manager.ivt
-    version: 0.25.0
-    obr: true
-    mvp: true
-    isolated: true
-    
-  - artifact: dev.galasa.cicsts.manager
-    version: 0.28.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
+  - artifact: galasa-managers-parent
+    version: 0.15.0
 
-  - artifact: dev.galasa.cicsts.manager.ivt
-    version: 0.22.0
-    obr: true
-    mvp: true
-    bom: true
-    isolated: true
-    
   - artifact: dev.galasa.cicsts.ceci.manager
     version: 0.25.0
     obr: true
-    mvp: true
     javadoc: true
     bom: true
+    mvp: true
     isolated: true
-    codecoverage: true
 
   - artifact: dev.galasa.cicsts.ceci.manager.ivt
     version: 0.25.0
     obr: true
-    mvp: true
     bom: true
+    mvp: true
     isolated: true
-    
+
   - artifact: dev.galasa.cicsts.ceda.manager
     version: 0.29.0
     obr: true
-    mvp: true
     javadoc: true
     bom: true
+    mvp: true
     isolated: true
-    codecoverage: true
-    
+
   - artifact: dev.galasa.cicsts.ceda.manager.ivt
     version: 0.22.0
     obr: true
     mvp: true
     isolated: true
-    
+
   - artifact: dev.galasa.cicsts.cemt.manager
     version: 0.25.0
     obr: true
-    mvp: true
     javadoc: true
     bom: true
+    mvp: true
     isolated: true
-    codecoverage: true
-    
+
   - artifact: dev.galasa.cicsts.cemt.manager.ivt
     version: 0.22.0
     obr: true
     mvp: true
     isolated: true
-    
+
+  - artifact: dev.galasa.cicsts.manager
+    version: 0.28.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.cicsts.manager.ivt
+    version: 0.25.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
   - artifact: dev.galasa.cicsts.resource.manager
     version: 0.25.0
     obr: true
@@ -97,8 +91,7 @@ managers:
     bom: true
     mvp: true
     isolated: true
-    codecoverage: true
-    
+
   - artifact: dev.galasa.cloud.manager
     version: 0.22.0
     obr: true
@@ -106,44 +99,7 @@ managers:
     bom: true
     mvp: true
     isolated: true
-    codecoverage: true
 
-  - artifact: dev.galasa.common
-    version: 0.25.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    
-  - artifact: dev.galasa.core.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.core.manager.ivt
-    version: 0.21.0
-    obr: true
-    mvp: true
-    isolated: true
-
-  - artifact: dev.galasa.db2.manager
-    version: 0.25.0
-    obr: true
-    bom: true
-    javadoc: true
-    mvp: true
-    isolated: true
-
-  - artifact: dev.galasa.db2.manager.ivt
-    version: 0.21.0
-    obr: true
-    mvp: true
-    isolated: true
-    
   - artifact: dev.galasa.docker.manager
     version: 0.25.0
     obr: true
@@ -151,106 +107,13 @@ managers:
     bom: true
     mvp: true
     isolated: true
-    codecoverage: true
-    
+
   - artifact: dev.galasa.docker.manager.ivt
     version: 0.25.0
     obr: true
     mvp: true
     isolated: true
-    
-  - artifact: dev.galasa.elasticlog.manager
-    version: 0.25.0
-    obr: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.elasticlog.manager.ivt
-    version: 0.21.0
-    obr: true
-    isolated: true
-    
-  - artifact: dev.galasa.galasaecosystem.manager
-    version: 0.27.0
-    obr: true
-    bom: true
-    isolated: true
-    codecoverage: true
 
-  - artifact: dev.galasa.galasaecosystem.manager.ivt
-    version: 0.21.0
-    obr: true
-    isolated: true
-
-  - artifact: dev.galasa.githubissue.manager
-    version: 0.25.0
-    obr: true
-    mvp: false
-    bom: true
-    isolated: false
-    
-  - artifact: dev.galasa.http.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.http.manager.ivt
-    version: 0.25.0
-    obr: true
-    mvp: true
-    isolated: true
-    
-  - artifact: dev.galasa.ipnetwork.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.java.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.java.ubuntu.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.java.windows.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.jmeter.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.jmeter.manager.ivt
-    version: 0.25.0
-    obr: true
-    isolated: true
-    
   - artifact: dev.galasa.kubernetes.manager
     version: 0.29.0
     obr: true
@@ -258,33 +121,54 @@ managers:
     bom: true
     mvp: true
     isolated: true
-    codecoverage: true
-    
+
   - artifact: dev.galasa.kubernetes.manager.ivt
     version: 0.21.0
     obr: true
     isolated: true
-    
+
   - artifact: dev.galasa.liberty.manager
     version: 0.21.0
     obr: true
+    javadoc: true
+    bom: true
     mvp: true
-    javadoc: true
-    bom: true
     isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.linux.manager
-    version: 0.21.0
+
+  - artifact: dev.galasa.openstack.manager
+    version: 0.26.0
     obr: true
     javadoc: true
     bom: true
     isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.linux.manager.ivt
-    version: 0.21.0
+
+  - artifact: dev.galasa.common
+    version: 0.25.0
     obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.http.manager
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.http.manager.ivt
+    version: 0.25.0
+    obr: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.ipnetwork.manager
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
     isolated: true
 
   - artifact: dev.galasa.mq.manager
@@ -293,28 +177,136 @@ managers:
     javadoc: true
     bom: true
     isolated: true
-    codecoverage: true
-  
+
   - artifact: dev.galasa.mq.manager.ivt
     version: 0.21.0
     obr: true
     bom: true
     isolated: true
-    
-  - artifact: dev.galasa.openstack.manager
-    version: 0.26.0
+
+  - artifact: dev.galasa.artifact.manager
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+    codecoverage: true
+
+  - artifact: dev.galasa.artifact.manager.ivt
+    version: 0.25.0
+    obr: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.core.manager
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.core.manager.ivt
+    version: 0.21.0
+    obr: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.textscan.manager
+    version: 0.21.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.db2.manager
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.db2.manager.ivt
+    version: 0.25.0
+    obr: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.eclipseruntime
+    version: 0.18.0
+
+  - artifact: dev.galasa.eclipseruntime.ubuntu.manager
+    version: 0.18.0
+
+  - artifact: dev.galasa.sem.manager
+    version: 0.25.0
+
+  - artifact: dev.galasa.java.manager
+    version: 0.21.0
     obr: true
     javadoc: true
     bom: true
     isolated: true
-    codecoverage: true
-    
+
+  - artifact: dev.galasa.java.ubuntu.manager
+    version: 0.21.0
+    obr: true
+    javadoc: true
+    bom: true
+    isolated: true
+
+  - artifact: dev.galasa.java.windows.manager
+    version: 0.21.0
+    obr: true
+    javadoc: true
+    bom: true
+    isolated: true
+
+  - artifact: dev.galasa.elasticlog.manager
+    version: 0.25.0
+    obr: true
+    bom: true
+    isolated: true
+
+  - artifact: dev.galasa.elasticlog.manager.ivt
+    version: 0.21.0
+    obr: true
+    isolated: true
+
   - artifact: dev.galasa.phoenix2.manager
     version: 0.25.0
     obr: true
     bom: true
     isolated: true
-    
+
+  - artifact: dev.galasa.galasaecosystem.manager
+    version: 0.27.0
+    obr: true
+    bom: true
+    isolated: true
+
+  - artifact: dev.galasa.galasaecosystem.manager.ivt
+    version: 0.21.0
+    obr: true
+    isolated: true
+
+  - artifact: dev.galasa.jmeter.manager
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    isolated: true
+
+  - artifact: dev.galasa.jmeter.manager.ivt
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    isolated: true
+
   - artifact: dev.galasa.selenium.manager
     version: 0.25.0
     obr: true
@@ -322,187 +314,8 @@ managers:
     bom: true
     mvp: true
     isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.selenium.manager.ivt
-    version: 0.21.0
-    obr: true
-    mvp: true
-    isolated: true
-    
-  - artifact: dev.galasa.sem.manager
-    version: 0.25.0
-    obr: true
-    bom: true
-    isolated: true
-    
-  - artifact: dev.galasa.textscan.manager
-    version: 0.21.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.windows.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zosbatch.rseapi.manager
-    version: 0.26.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-        
-  - artifact: dev.galasa.zosbatch.zosmf.manager
-    version: 0.26.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
 
-  - artifact: dev.galasa.zosconsole.oeconsol.manager
-    version: 0.21.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zosconsole.zosmf.manager
-    version: 0.25.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zosfile.rseapi.manager
-    version: 0.25.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zosfile.zosmf.manager
-    version: 0.25.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zosliberty.manager
-    version: 0.21.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zosliberty.angel.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zos.manager
-    version: 0.28.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zos.manager.ivt
-    version: 0.28.0
-    obr: true
-    mvp: true
-    isolated: true
-      
-  - artifact: dev.galasa.zosprogram.manager 
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zosmf.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zosrseapi.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zossecurity.manager
-    version: 0.29.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zostsocommand.ssh.manager
-    version: 0.21.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zosunixcommand.ssh.manager
-    version: 0.21.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zos3270.common
-    version: 0.28.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zos3270.manager
-    version: 0.28.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zos3270.manager.ivt
+  - artifact: dev.galasa.selenium.manager.ivt
     version: 0.21.0
     obr: true
     mvp: true
@@ -512,6 +325,173 @@ managers:
     version: 0.25.0
     obr: true
     javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.vtp.manager.ivt
+    version: 0.21.0
+
+  - artifact: dev.galasa.linux.manager
+    version: 0.21.0
+    obr: true
+    javadoc: true
+    bom: true
+    isolated: true
+
+  - artifact: dev.galasa.linux.manager.ivt
+    version: 0.21.0
+    obr: true
+    isolated: true
+
+  - artifact: dev.galasa.windows.manager
+    version: 0.21.0
+    obr: true
+    javadoc: true
+    bom: true
+    isolated: true
+
+  - artifact: dev.galasa.githubissue.manager
+    version: 0.25.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zos.manager
+    version: 0.28.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zos.manager.ivt
+    version: 0.28.0
+    obr: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zos3270.common
+    version: 0.28.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zos3270.manager
+    version: 0.28.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zos3270.manager.ivt
+    version: 0.21.0
+    obr: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosbatch.rseapi.manager
+    version: 0.26.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosbatch.zosmf.manager
+    version: 0.26.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosconsole.oeconsol.manager
+    version: 0.21.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosconsole.zosmf.manager
+    version: 0.25.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosfile.rseapi.manager
+    version: 0.25.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosfile.zosmf.manager
+    version: 0.25.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosliberty.angel.manager
+    version: 0.21.0
+    obr: true
+    javadoc: true
+    bom: true
+    isolated: true
+
+  - artifact: dev.galasa.zosliberty.manager
+    version: 0.21.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosmf.manager
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosprogram.manager
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosrseapi.manager
+    version: 0.25.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zossecurity.manager
+    version: 0.29.0
+    obr: true
+    javadoc: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zostsocommand.ssh.manager
+    version: 0.21.0
+    obr: true
+    bom: true
+    mvp: true
+    isolated: true
+
+  - artifact: dev.galasa.zosunixcommand.ssh.manager
+    version: 0.21.0
+    obr: true
     bom: true
     mvp: true
     isolated: true

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,221 @@
+#! /usr/bin/env bash 
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Objectives: Sets the version number, and/or re-build the release.yaml
+#
+# Environment variable over-rides:
+# None
+# 
+#-----------------------------------------------------------------------------------------                   
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+# echo "Running from directory ${BASEDIR}"
+export ORIGINAL_DIR=$(pwd)
+# cd "${BASEDIR}"
+
+cd "${BASEDIR}/.."
+WORKSPACE_DIR=$(pwd)
+
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------                   
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------                   
+underline() { printf "${underline}${bold}%s${reset}\n" "$@"
+}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@"
+}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@"
+}
+debug() { printf "${white}%s${reset}\n" "$@"
+}
+info() { printf "${white}➜ %s${reset}\n" "$@"
+}
+success() { printf "${green}✔ %s${reset}\n" "$@"
+}
+error() { printf "${red}✖ %s${reset}\n" "$@"
+}
+warn() { printf "${tan}➜ %s${reset}\n" "$@"
+}
+bold() { printf "${bold}%s${reset}\n" "$@"
+}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@"
+}
+
+#-----------------------------------------------------------------------------------------                   
+# Functions
+#-----------------------------------------------------------------------------------------                   
+function usage {
+    h1 "Syntax"
+    cat << EOF
+set-version.sh [OPTIONS]
+Options are:
+-v | --version xxx : Mandatory. Set the version number to something explicitly. 
+    Re-builds the release.yaml based on the contents of sub-projects.
+    For example '--version 0.29.0'
+EOF
+}
+
+#-----------------------------------------------------------------------------------------                   
+# Process parameters
+#-----------------------------------------------------------------------------------------                   
+overall_version=""
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -v | --version )        export overall_version=$1
+                                shift
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+if [[ -z $overall_version ]]; then 
+    error "Missing mandatory '--version' argument."
+    usage
+    exit 1
+fi
+
+function build_release_yaml {
+    target_file=$1
+
+
+    cd $BASEDIR
+
+    manager_folders_list="$target_file-temp-managers-folders.txt"
+    find . | grep "build.gradle" | sed "s/\/build.gradle//g" | sort > $manager_folders_list
+
+    cat << EOF > $target_file
+#
+# Copyright contributors to the Galasa project 
+#
+
+# -----------------------------------------------------------
+#
+#                         WARNING
+#
+# This file is periodically re-generated from the contents of 
+# the repository, so don't make changes here manually please.
+# -----------------------------------------------------------
+
+
+apiVersion: galasa.dev/v1alpha
+kind: Release
+metadata:
+  name: galasa-release
+    
+managers:
+  bundles:
+
+#
+# Manager 
+#  
+EOF
+
+
+    # Results in a file containing things like this:
+    # ./galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt
+    # ./galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager
+    # ./galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager
+
+    while IFS= read -r manager_folder
+    do 
+        info "Processing folder $manager_folder..."
+        manager_version=$(cat $manager_folder/build.gradle | grep "version =" | cut -f2 -d"'")
+
+        manager_name=$(cat $manager_folder/settings.gradle | grep "rootProject.name =" | cut -f2 -d"'")
+
+
+        if [[ "${manager_name}" != "" ]]; then 
+
+            # The settings.gradle file also contains something like this:
+            # include_in_obr = true
+            # include_in_javadoc = true
+            # include_in_bom = true
+            # include_in_mvp = true
+            # include_in_isolated = true
+            # include_in_code_coverage =  true
+            # ... which we need to read-in.
+            include_in_obr=$(cat $manager_folder/settings.gradle | grep -v "\/\/" | grep "include_in_obr" | sed "s/=/ /g" | xargs | cut -f2 -d' ')
+            include_in_javadoc=$(cat $manager_folder/settings.gradle | grep -v "\/\/" | grep "include_in_javadoc" | sed "s/=/ /g" | xargs | cut -f2 -d' ')
+            include_in_bom=$(cat $manager_folder/settings.gradle | grep -v "\/\/" | grep "include_in_bom" | sed "s/=/ /g" | xargs | cut -f2 -d' ')
+            include_in_mvp=$(cat $manager_folder/settings.gradle | grep -v "\/\/" | grep "include_in_mvp" | sed "s/=/ /g" | xargs | cut -f2 -d' ')
+            include_in_isolated=$(cat $manager_folder/settings.gradle | grep -v "\/\/" | grep "include_in_isolated" | sed "s/=/ /g" | xargs | cut -f2 -d' ')
+            include_in_code_coverage=$(cat $manager_folder/settings.gradle | grep -v "\/\/" | grep "include_in_code_coverage" | sed "s/=/ /g" | xargs | cut -f2 -d' ')
+
+            info "Manager '$manager_name' is at version '$manager_version'"
+
+            echo "" >> $target_file
+            echo "  - artifact: $manager_name" >> $target_file
+            echo "    version: $manager_version" >> $target_file
+            
+            if [[ "${include_in_obr}" != "" ]]; then 
+                echo "    obr: $include_in_obr" >> $target_file
+            fi
+
+            if [[ "${include_in_javadoc}" != "" ]]; then 
+                echo "    javadoc: $include_in_javadoc" >> $target_file
+            fi
+
+            if [[ "${include_in_bom}" != "" ]]; then 
+                echo "    bom: $include_in_bom" >> $target_file
+            fi
+
+            if [[ "${include_in_mvp}" != "" ]]; then 
+                echo "    mvp: $include_in_mvp" >> $target_file
+            fi
+
+            if [[ "${include_in_isolated}" != "" ]]; then 
+                echo "    isolated: $include_in_isolated" >> $target_file
+            fi
+
+            if [[ "${include_in_code_coverage}" != "" ]]; then 
+                echo "    codecoverage: $include_in_code_coverage" >> $target_file
+            fi
+
+    fi
+    
+    done < $manager_folders_list
+
+    rm $manager_folders_list
+
+}
+
+rm -fr $BASEDIR/temp
+mkdir -p $BASEDIR/temp
+
+build_release_yaml $BASEDIR/temp/release.yaml
+
+diff ${BASEDIR}/release.yaml $BASEDIR/temp/release.yaml > /dev/null
+is_different=$?
+if [[ "${is_different}" == "0" ]]; then
+    info "The generated yaml and the release.yaml are the same, so not replacing it."
+else
+    info "Replacing the generated yaml with the release.yaml file..."
+    cp $BASEDIR/temp/release.yaml ${BASEDIR}/release.yaml
+fi
+
+success "OK"


### PR DESCRIPTION
- [x] new script `set-version.sh` which re-builds release.yaml from all the data now sited in each manager settings.gradle. 


Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
