### PR TITLE
mcobbett build release yaml 2

### DIFF
--- a/galasa-managers-parent/build.gradle
+++ b/galasa-managers-parent/build.gradle
@@ -187,7 +187,10 @@ publishing {
             artifact myReleaseYaml
             artifactId "dev.galasa.managers.manifest"
             groupId 'dev.galasa'
-            version version
+            
+            pom {
+                packaging = "pom"
+            }
         }
     }
     repositories {


### PR DESCRIPTION
- Pom.xml should declare pom.xml as the packaging type, so that the obr project has a chance to pick it up.
