### PR TITLE
Check stepname before updating existing spool files

### DIFF
--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa zOS Manager'
 
-version = '0.28.0'
+version = '0.31.0'
 
 dependencies {
     api project     (':galasa-managers-comms-parent:dev.galasa.ipnetwork.manager')
@@ -15,7 +15,7 @@ dependencies {
 // Note: These values are consumed by the parent build process
 // They indicate which packages of functionality this OSGi bundle should be delivered inside,
 // or referenced from.
-// The settings here are gathered together by the build process to create a release.yaml file 
+// The settings here are gathered together by the build process to create a release.yaml file
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zosbatch/internal/ZosBatchJobOutputImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zosbatch/internal/ZosBatchJobOutputImpl.java
@@ -10,9 +10,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import dev.galasa.zosbatch.IZosBatchJob;
 import dev.galasa.zosbatch.IZosBatchJobOutput;
 import dev.galasa.zosbatch.IZosBatchJobOutputSpoolFile;
@@ -31,8 +28,6 @@ public class ZosBatchJobOutputImpl implements IZosBatchJobOutputSpi {
     
     private ArrayList<IZosBatchJobOutputSpoolFile> spoolFiles = new ArrayList<>();
 
-    private static final Log logger = LogFactory.getLog(ZosBatchJobOutputImpl.class);
-
     public ZosBatchJobOutputImpl(IZosBatchJob batchJob, String jobname, String jobid) {
     	this.batchJob = batchJob;
         this.jobname = jobname;
@@ -49,7 +44,6 @@ public class ZosBatchJobOutputImpl implements IZosBatchJobOutputSpi {
         //the outline of the spool may already exist.  BUT the content might not - if it exists then update it
         for (IZosBatchJobOutputSpoolFile spool : spoolFiles) {
             if (ddname.equals(spool.getDdname()) && (stepname != null && stepname.equals(spool.getStepname()))) {
-                logger.trace("Updating spool file for batch job " + this.jobid + " - step: '" + stepname + "', DD: '" + ddname + "'");
                 spool.setRecords(records);
                 return;
             }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zosbatch/internal/ZosBatchJobOutputImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/main/java/dev/galasa/zosbatch/internal/ZosBatchJobOutputImpl.java
@@ -10,6 +10,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import dev.galasa.zosbatch.IZosBatchJob;
 import dev.galasa.zosbatch.IZosBatchJobOutput;
 import dev.galasa.zosbatch.IZosBatchJobOutputSpoolFile;
@@ -20,13 +23,15 @@ import dev.galasa.zosbatch.spi.IZosBatchJobOutputSpi;
  * Implementation of {@link IZosBatchJobOutput}
  *
  */
-public class ZosBatchJobOutputImpl implements IZosBatchJobOutputSpi, Iterable<IZosBatchJobOutputSpoolFile> {
+public class ZosBatchJobOutputImpl implements IZosBatchJobOutputSpi {
 
 	private IZosBatchJob batchJob;
     private String jobname;
     private String jobid;
     
     private ArrayList<IZosBatchJobOutputSpoolFile> spoolFiles = new ArrayList<>();
+
+    private static final Log logger = LogFactory.getLog(ZosBatchJobOutputImpl.class);
 
     public ZosBatchJobOutputImpl(IZosBatchJob batchJob, String jobname, String jobid) {
     	this.batchJob = batchJob;
@@ -42,8 +47,9 @@ public class ZosBatchJobOutputImpl implements IZosBatchJobOutputSpi, Iterable<IZ
     @Override
     public void addSpoolFile(String stepname, String procstep, String ddname, String id, String records) {
         //the outline of the spool may already exist.  BUT the content might not - if it exists then update it
-        for(IZosBatchJobOutputSpoolFile spool : spoolFiles){
-            if(ddname.equals(spool.getDdname())){
+        for (IZosBatchJobOutputSpoolFile spool : spoolFiles) {
+            if (ddname.equals(spool.getDdname()) && (stepname != null && stepname.equals(spool.getStepname()))) {
+                logger.trace("Updating spool file for batch job " + this.jobid + " - step: '" + stepname + "', DD: '" + ddname + "'");
                 spool.setRecords(records);
                 return;
             }
@@ -98,7 +104,7 @@ public class ZosBatchJobOutputImpl implements IZosBatchJobOutputSpi, Iterable<IZ
             
             @Override
             public void remove() {
-                throw new UnsupportedOperationException("Object can not be updated");
+                throw new UnsupportedOperationException("Object cannot be updated");
             }
         };
     }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/test/java/dev/galasa/zosbatch/internal/TestZosBatchJobOutputImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos.manager/src/test/java/dev/galasa/zosbatch/internal/TestZosBatchJobOutputImpl.java
@@ -6,8 +6,11 @@
 package dev.galasa.zosbatch.internal;
 
 import java.util.Iterator;
+import java.util.List;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,82 +24,137 @@ import dev.galasa.zosbatch.ZosBatchManagerException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestZosBatchJobOutputImpl {
-    
+
     @Mock
     private IZosBatchJob zosBatchJobMock;
-    
-    private ZosBatchJobOutputImpl zosBatchJobOutput; 
+
+    private ZosBatchJobOutputImpl zosBatchJobOutput;
 
     private static final String JOBNAME = "jobname";
 
     private static final String JOBID = "jobid";
-    
+
     private static final String STEPNAME = "stepname";
-    
+
     private static final String PROCSTEP = "procstep";
-    
+
     private static final String DDNAME = "ddname";
-    
+
     private static final String ID = "id";
 
     private static final String RECORDS = "records";
-    
+
     @Before
     public void setup() throws ZosBatchManagerException {
         zosBatchJobOutput = new ZosBatchJobOutputImpl(zosBatchJobMock, JOBNAME, JOBID);
     }
-    
+
     @Test
-    public void testAddJcl() throws ZosBatchException {
+    public void testAddJclCreatesSpoolFileWithGivenRecords() throws ZosBatchException {
         zosBatchJobOutput.addJcl(RECORDS);
-        Assert.assertEquals("getJobname() should return the supplied value", JOBNAME, zosBatchJobOutput.getJobname());
-        Assert.assertEquals("getJobid() should return the supplied value", JOBID, zosBatchJobOutput.getJobid());
-        Assert.assertEquals("toString() should return the supplied values of JOBNAME_JOBID", JOBNAME + "_" + JOBID, zosBatchJobOutput.toString());
+
+        List<IZosBatchJobOutputSpoolFile> spoolFiles = zosBatchJobOutput.getSpoolFiles();
+        assertThat(spoolFiles).hasSize(1);
+
+        IZosBatchJobOutputSpoolFile expectedSpoolFile = new ZosBatchJobOutputSpoolFileImpl(zosBatchJobMock, JOBNAME,
+                JOBID, "", "", "JESJCLIN", "JCL", RECORDS);
+        assertThat(spoolFiles.get(0)).usingRecursiveComparison().isEqualTo(expectedSpoolFile);
     }
 
     @Test
-    public void testAdd() throws ZosBatchException {
+    public void testAddSingleSpoolFileAppendsNewSpoolFile() throws ZosBatchException {
         zosBatchJobOutput.addSpoolFile(STEPNAME, PROCSTEP, DDNAME, ID, RECORDS);
-        Assert.assertEquals("getJobname() should return the supplied value", JOBNAME, zosBatchJobOutput.getJobname());
-        Assert.assertEquals("getJobid() should return the supplied value", JOBID, zosBatchJobOutput.getJobid());
-        Assert.assertEquals("toString() should return the supplied values of JOBNAME_JOBID", JOBNAME + "_" + JOBID, zosBatchJobOutput.toString());
+
+        List<IZosBatchJobOutputSpoolFile> spoolFiles = zosBatchJobOutput.getSpoolFiles();
+        assertThat(spoolFiles).hasSize(1);
+
+        IZosBatchJobOutputSpoolFile expectedSpoolFile = new ZosBatchJobOutputSpoolFileImpl(zosBatchJobMock, JOBNAME,
+                JOBID, STEPNAME, PROCSTEP, DDNAME, ID, RECORDS);
+        assertThat(spoolFiles.get(0)).usingRecursiveComparison().isEqualTo(expectedSpoolFile);
     }
+
     @Test
-    public void testGetSpoolFiles() throws ZosBatchException {
+    public void testAddDifferentSpoolFilesAppendsMultipleSpoolFiles() throws ZosBatchException {
+        zosBatchJobOutput.addSpoolFile("STEP1", "PROCSTEP1", "DD1", "ID1", RECORDS);
+        zosBatchJobOutput.addSpoolFile("STEP2", "PROCSTEP2", "DD2", "ID2", RECORDS);
+
+        List<IZosBatchJobOutputSpoolFile> spoolFiles = zosBatchJobOutput.getSpoolFiles();
+        assertThat(spoolFiles).hasSize(2);
+
+        IZosBatchJobOutputSpoolFile expectedFirstSpoolFile = new ZosBatchJobOutputSpoolFileImpl(zosBatchJobMock,
+                JOBNAME, JOBID, "STEP1", "PROCSTEP1", "DD1", "ID1", RECORDS);
+        assertThat(spoolFiles.get(0)).usingRecursiveComparison().isEqualTo(expectedFirstSpoolFile);
+
+        IZosBatchJobOutputSpoolFile expectedSecondSpoolFile = new ZosBatchJobOutputSpoolFileImpl(zosBatchJobMock,
+                JOBNAME, JOBID, "STEP2", "PROCSTEP2", "DD2", "ID2", RECORDS);
+        assertThat(spoolFiles.get(1)).usingRecursiveComparison().isEqualTo(expectedSecondSpoolFile);
+    }
+
+    @Test
+    public void testAddSpoolFilesWithSameDDNameAppendsSpoolFiles() throws ZosBatchException {
+        zosBatchJobOutput.addSpoolFile("STEP1", PROCSTEP, DDNAME, ID, RECORDS);
+        zosBatchJobOutput.addSpoolFile("STEP2", PROCSTEP, DDNAME, ID, RECORDS);
+
+        List<IZosBatchJobOutputSpoolFile> spoolFiles = zosBatchJobOutput.getSpoolFiles();
+        assertThat(spoolFiles).hasSize(2);
+
+        IZosBatchJobOutputSpoolFile expectedFirstSpoolFile = new ZosBatchJobOutputSpoolFileImpl(zosBatchJobMock,
+                JOBNAME, JOBID, "STEP1", PROCSTEP, DDNAME, ID, RECORDS);
+        assertThat(spoolFiles.get(0)).usingRecursiveComparison().isEqualTo(expectedFirstSpoolFile);
+
+        IZosBatchJobOutputSpoolFile expectedSecondSpoolFile = new ZosBatchJobOutputSpoolFileImpl(zosBatchJobMock,
+                JOBNAME, JOBID, "STEP2", PROCSTEP, DDNAME, ID, RECORDS);
+        assertThat(spoolFiles.get(1)).usingRecursiveComparison().isEqualTo(expectedSecondSpoolFile);
+    }
+
+    @Test
+    public void testAddSpoolFilesWithSameDDNameAndStepNameUpdatesExistingSpoolFile() throws ZosBatchException {
+        zosBatchJobOutput.addSpoolFile(STEPNAME, PROCSTEP, DDNAME, ID, "");
+        zosBatchJobOutput.addSpoolFile(STEPNAME, PROCSTEP, DDNAME, ID, RECORDS);
+
+        List<IZosBatchJobOutputSpoolFile> spoolFiles = zosBatchJobOutput.getSpoolFiles();
+        assertThat(spoolFiles).hasSize(1);
+
+        IZosBatchJobOutputSpoolFile expectedSpoolFile = new ZosBatchJobOutputSpoolFileImpl(zosBatchJobMock, JOBNAME,
+                JOBID, STEPNAME, PROCSTEP, DDNAME, ID, RECORDS);
+        assertThat(spoolFiles.get(0)).usingRecursiveComparison().isEqualTo(expectedSpoolFile);
+    }
+
+    @Test
+    public void testToListReturnsAListOfAllSpoolFileContents() throws ZosBatchException {
         zosBatchJobOutput.addJcl("JCL");
-        Assert.assertNotNull("getSpoolFiles() should not return null", zosBatchJobOutput.getSpoolFiles());
+        assertThat(zosBatchJobOutput.toList()).isNotNull();
     }
-    
+
     @Test
-    public void testToList() throws ZosBatchException {
-        zosBatchJobOutput.addJcl("JCL");
-        Assert.assertNotNull("toList() should return a value", zosBatchJobOutput.toList());
-    }
-    
-    @Test
-    public void testIterator() throws ZosBatchException {
+    public void testIteratorCreatesAnIteratorOverExistingSpoolFiles() throws ZosBatchException {
         zosBatchJobOutput.addJcl("JCL");
         Iterator<IZosBatchJobOutputSpoolFile> iterator = zosBatchJobOutput.iterator();
-        
-        Assert.assertTrue("hasNext() should return true", iterator.hasNext());
-        
-        Assert.assertNotNull("next() should return a value", iterator.next());
-        
-        String expectedMessage = "Object can not be updated";
-        UnsupportedOperationException expectedException = Assert.assertThrows("expected exception should be thrown", UnsupportedOperationException.class, ()->{
-        	iterator.remove();
-        });
-    	Assert.assertEquals("exception should contain expected message", expectedMessage, expectedException.getMessage());
+
+        assertThat(iterator.hasNext()).isTrue();
+
+        assertThat(iterator.next()).isNotNull();
+
+        String expectedMessage = "Object cannot be updated";
+        assertThatThrownBy(() -> iterator.remove())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(expectedMessage);
     }
-    
+
     @Test
-    public void testSize() throws ZosBatchException {
+    public void testSizeReturnsTheNumberOfSpoolFilesThatExist() throws ZosBatchException {
         zosBatchJobOutput.addJcl("JCL");
-        Assert.assertEquals("size() should return a 1", 1, zosBatchJobOutput.size());
+        assertThat(zosBatchJobOutput.size()).isEqualTo(1);
     }
-    
+
     @Test
-    public void testIsEmpty() throws ZosBatchException {
-        Assert.assertTrue("isEmpty() should return a true", zosBatchJobOutput.isEmpty());
+    public void testIsEmptyShouldReturnTrueWhenNoSpoolFilesExist() throws ZosBatchException {
+        assertThat(zosBatchJobOutput.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testIsEmptyShouldReturnFalseWhenSpoolFilesExist() throws ZosBatchException {
+        zosBatchJobOutput.addJcl("JCL");
+        assertThat(zosBatchJobOutput.isEmpty()).isFalse();
     }
 }

--- a/release.yaml
+++ b/release.yaml
@@ -422,7 +422,7 @@ managers:
     codecoverage: true
     
   - artifact: dev.galasa.zos.manager
-    version: 0.28.0
+    version: 0.31.0
     obr: true
     javadoc: true
     bom: true


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1632

- Added an additional check to `addSpoolFile` to prevent existing spool files with different stepnames from being overwritten if they share the same ddname
- Improved existing unit tests for the `ZosBatchJobOutputImpl` class, where some tests weren't asserting anything useful
- Bumped dev.galasa.zos.manager to 0.31.0