### PR TITLE
Security upgrade httpd from 2.4.29 to 2.4.58 

### DIFF
--- a/galasa-managers-parent/galasa-uber-javadoc/src/main/resources/Dockerfile
+++ b/galasa-managers-parent/galasa-uber-javadoc/src/main/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.4.29
+FROM httpd:2.4.58
 
 RUN rm -v /usr/local/apache2/htdocs/*
 


### PR DESCRIPTION
Based on the Snyk security report, I have upgraded the version of the httpd image we use in the Dockerfile for the galasa-uber-javadoc.

The httpd image at version 2.4.29 reportedly has 22 Critical vulnerabilities and 66 High. Upgrading to version 2.4.58 reduces the number of Critical vulnerabilities to 1 and 0 High.

This issue contributes to story [#1739 ](https://github.com/galasa-dev/projectmanagement/issues/1739)