### PR TITLE
Don't fall over if response isn't json

### DIFF
--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/HttpClientResponse.java
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/src/main/java/dev/galasa/http/HttpClientResponse.java
@@ -274,17 +274,21 @@ public class HttpClientResponse<T> {
                 if (response.getStatusCode() == HttpStatus.SC_OK || contentOnBadResponse) {
                     String sResponse = EntityUtils.toString(httpResponse.getEntity());
                     
-//                    JsonReader reader = new JsonReader(new InputStreamReader(httpResponse.getEntity().getContent()));
-                    JsonElement jsonElement = null;
-                    try{
-                        jsonElement = new GalasaGson().fromJson(sResponse, JsonElement.class);
-                    }catch(JsonSyntaxException jse){
-                        System.err.println("Unable to parse JSON from the following: " + sResponse);
-                        throw jse;
-                    }
-                    if (jsonElement != null) {
-                        JsonObject json = jsonElement.getAsJsonObject();
-                        response.setContent(json);
+                    if (sResponse.trim().startsWith("{")) {
+//                      JsonReader reader = new JsonReader(new InputStreamReader(httpResponse.getEntity().getContent()));
+                        JsonElement jsonElement = null;
+                        try{
+                            jsonElement = new GalasaGson().fromJson(sResponse, JsonElement.class);
+                        }catch(JsonSyntaxException jse){
+                            System.err.println("Unable to parse JSON from the following: " + sResponse);
+                            throw jse;
+                        }
+                        if (jsonElement != null) {
+                            JsonObject json = jsonElement.getAsJsonObject();
+                            response.setContent(json);
+                        }
+                    } else {
+                      System.err.println("Did not attempt to parse JSON from the following: " + sResponse);
                     }
                 } else {
                     EntityUtils.consume(httpResponse.getEntity());


### PR DESCRIPTION
While developing a Galasa manager, to not reinvent the wheel I'm reusing the HTTP method helpers in the HTTPManager.

I am calling endpoints within a CICS region with these helpers. Requests to these endpoints are passed to a CICS program, which always returns JSON. However, whilst forcing how well it handled `401` errors, I found that unauthenticated errors are actually handled by another part of CICS, which returns `text/html`. This means 99% of the time, using `getJson()` or `postJson()` I will get back JSON, but if a password is wrong, it will be `text/html`. There is nothing in CICS I can change currently to fix this behaviour.

I've put in this fix (which might not be the right solution) to start a conversation about the right way to solve it. But, if a response doesn't start with `{`, then it cannot be JSON, therefore don't attempt to parse it as JSON. This helps my scenario, because a JSONSyntaxException isn't raised (which contains nothing about the 401 response) and my code gets back a response with a status code, message, and no content, which I can then appropriately handle. Maybe whatever response it did get, should be forced into a JSON object here as plain text? e.g.:

```
{
  "response": "<html>401 unauthenticated from CICS</html>"
}
```