### PR TITLE
Added spi.utils package as bundle import to http manager as showing a…

### DIFF
--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/bnd.bnd
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.http.manager/bnd.bnd
@@ -5,6 +5,7 @@ Import-Package: com.google.gson,\
     dev.galasa,\
     dev.galasa.framework.spi,\
     dev.galasa.framework.spi.language,\
+    dev.galasa.framework.spi.utils,\
     dev.galasa.http.spi,\
     dev.galasa.common,\
     javax.net.ssl,\


### PR DESCRIPTION
…s NoClassDefError

```
14/02/2024 15:51:30.321 ERROR dev.galasa.boot.Launcher.launch - Unable to run test class
dev.galasa.boot.LauncherException: java.lang.NoClassDefFoundError: dev/galasa/framework/spi/utils/GalasaGson
        at dev.galasa.boot.felix.FelixFramework.runTest(FelixFramework.java:235)
        at dev.galasa.boot.Launcher.launch(Launcher.java:176)
        at dev.galasa.boot.Launcher.main(Launcher.java:126)
Caused by: java.lang.NoClassDefFoundError: dev/galasa/framework/spi/utils/GalasaGson
        at dev.galasa.http.HttpClientResponse.jsonResponse(HttpClientResponse.java:280)
        at dev.galasa.http.HttpClientResponse.jsonResponse(HttpClientResponse.java:252)
        at dev.galasa.http.internal.HttpClientImpl.executeJsonRequest(HttpClientImpl.java:194)
        at dev.galasa.http.internal.HttpClientImpl.deleteJson(HttpClientImpl.java:189)
        at dev.galasa.zosmf.internal.ZosmfImpl.delete(ZosmfImpl.java:240)
        at dev.galasa.zosmf.internal.ZosmfRestApiProcessor.sendRequest(ZosmfRestApiProcessor.java:91)
        at 
```

As can be seen in the error, it is the HttpClientResponse class that cannot find the GalasaGson class. The http manager package did not seem to have the bundle as an import so I have added it.