### PR TITLE
Fix ZosManagerBatchIVT failures

### DIFF
--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa zOS Batch Manager - RSE API Implementation'
 
-version = '0.31.0'
+version = '0.33.0'
 
 dependencies {
     implementation project(':galasa-managers-zos-parent:dev.galasa.zosrseapi.manager')

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/src/main/java/dev/galasa/zosbatch/rseapi/manager/internal/RseapiJobStatus.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/src/main/java/dev/galasa/zosbatch/rseapi/manager/internal/RseapiJobStatus.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.zosbatch.rseapi.manager.internal;
+
+/**
+ * An enum to hold the statuses of a batch job that can be returned from the RSE
+ * API.
+ */
+public enum RseapiJobStatus {
+    HOLD("HOLD"),
+    ACTIVE("ACTIVE"),
+    ABEND("ABEND", true),
+    COMPLETED("COMPLETED", true),
+    COMPLETION("COMPLETION", true),
+    NOTFOUND("NOT_FOUND", true),
+    UNKNOWN("UNKNOWN");
+
+    private String value;
+    private boolean isCompleteStatus;
+
+    private RseapiJobStatus(String value) {
+        this.value = value;
+        this.isCompleteStatus = false;
+    }
+
+    private RseapiJobStatus(String value, boolean isCompleteStatus) {
+        this.value = value;
+        this.isCompleteStatus = isCompleteStatus;
+    }
+
+    /**
+     * Converts a given string into an RseapiJobStatus enum value. If no enum value
+     * matches, then the UNKNOWN value will be assigned.
+     *
+     * @param jobStatus the string to convert
+     * @return an RseapiJobStatus enum value
+     */
+    public static RseapiJobStatus getJobStatusFromString(String jobStatus) {
+        for (RseapiJobStatus status : values()) {
+            if (status.toString().equals(jobStatus)) {
+                return status;
+            }
+        }
+        return RseapiJobStatus.UNKNOWN;
+    }
+
+    public boolean isComplete() {
+        return this.isCompleteStatus;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+}

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/src/main/java/dev/galasa/zosbatch/rseapi/manager/internal/RseapiZosBatchJobImpl.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/src/main/java/dev/galasa/zosbatch/rseapi/manager/internal/RseapiZosBatchJobImpl.java
@@ -590,16 +590,18 @@ public class RseapiZosBatchJobImpl implements IZosBatchJob {
             this.owner = jsonNull(responseBody, PROP_OWNER);
             this.type = jsonNull(responseBody, PROP_TYPE);
             this.statusString = jsonNull(responseBody, PROP_STATUS);
-            if (this.statusString != null && "COMPLETION".equals(this.statusString) ||
-            	this.statusString != null && "ABEND".equals(this.statusString)) {
-                this.jobComplete = true;
-            } else if (this.statusString != null && "NOT_FOUND".equals(this.statusString)) {
-        		logger.trace("JOBID=" + this.jobid + " JOBNAME=" + this.jobname.getName() + " NOT FOUND");
+
+            // Update the completion status of this batch job
+            RseapiJobStatus status = RseapiJobStatus.getJobStatusFromString(this.statusString);
+            this.jobComplete = status.isComplete();
+
+            if (status == RseapiJobStatus.NOTFOUND) {
+                logger.trace("JOBID=" + this.jobid + " JOBNAME=" + this.jobname.getName() + " NOT FOUND");
                 this.jobNotFound = true;
                 this.status = JobStatus.NOTFOUND;
-                this.jobComplete = true;
             }
             setStatus(this.statusString);
+
             String retcodeProperty = jsonNull(responseBody, PROP_RETCODE);
             if (retcodeProperty != null) {
                 this.retcode = retcodeProperty;

--- a/release.yaml
+++ b/release.yaml
@@ -357,7 +357,7 @@ managers:
     codecoverage: true
     
   - artifact: dev.galasa.zosbatch.rseapi.manager
-    version: 0.31.0
+    version: 0.33.0
     obr: true
     bom: true
     mvp: true


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1831

When the RSE API was used when running the ZosManagerBatchIVT, the tests would fail when waiting for submitted jobs to finish, even though the jobs had finished. The manager was not recognising the "COMPLETED" status returned from the RSE API and was instead looking only for "COMPLETION", "ABEND", or "NOT_FOUND", which was causing the tests to time out.

## Changes
- Added an enum to capture the statuses returned by the RSE API
- Used the new enum when updating the completion status of a batch job