### PR TITLE
updated version of dev.galasa package to 0.34.0

### DIFF
--- a/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+++ b/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    api            'dev.galasa:dev.galasa:0.21.0'
+    api            'dev.galasa:dev.galasa:0.34.0'
     implementation 'dev.galasa:dev.galasa.framework:0.34.0'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'org.osgi:org.osgi.core:6.0.0'

--- a/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
+++ b/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.ivt.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'dev.galasa:dev.galasa:0.21.0'
+    implementation 'dev.galasa:dev.galasa:0.34.0'
     
     implementation 'commons-logging:commons-logging:1.2'
     


### PR DESCRIPTION
## Why?

Following the bumping of dev.galasa to a new version, the extensions need to point to the same version in order to pick up the latest changes