### PR TITLE
added com.ibm.dataacess to the bundle package imports

### DIFF
--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/bnd.bnd
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/bnd.bnd
@@ -1,5 +1,5 @@
 -snapshot: ${tstamp}
 Bundle-Name: Galasa Db2 Manager IVT
 Export-Package: dev.galasa.db2.manager.ivt
-Import-Package: javax.validation.constraints, \
+Import-Package: !javax.validation.constraints, \
                 *

--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/bnd.bnd
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/bnd.bnd
@@ -1,5 +1,5 @@
 -snapshot: ${tstamp}
 Bundle-Name: Galasa Db2 Manager IVT
 Export-Package: dev.galasa.db2.manager.ivt
-Import-Package: !javax.validation.constraints, \
+Import-Package: javax.validation.constraints, \
                 *

--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/build.gradle
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa Db2 Manager IVTs'
 
-version = '0.25.0'
+version = '0.34.0'
 
 dependencies {
     implementation project(':galasa-managers-database-parent:dev.galasa.db2.manager')

--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/bnd.bnd
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/bnd.bnd
@@ -5,7 +5,7 @@ Export-Package: dev.galasa.db2,\
 Import-Package: !javax.validation.constraints, \
                 !com.ibm.bidiTools.bdlayout, \
                 !com.ibm.cics.server, \
-                !com.ibm.dataaccess, \
+                com.ibm.dataaccess, \
                 !COM.ibm.db2os390.sqlj.runtime, \
                 !com.ibm.jvm, \
                 !com.ibm.net, \

--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa Db2 Manager'
 
-version = '0.25.0'
+version = '0.34.0'
 
 dependencies {
 	// implementation project(':galasa-managers-core-parent:dev.galasa.artifact.manager')

--- a/release.yaml
+++ b/release.yaml
@@ -134,7 +134,7 @@ managers:
     isolated: true
 
   - artifact: dev.galasa.db2.manager
-    version: 0.25.0
+    version: 0.34.0
     obr: true
     bom: true
     javadoc: true
@@ -142,7 +142,7 @@ managers:
     isolated: true
 
   - artifact: dev.galasa.db2.manager.ivt
-    version: 0.21.0
+    version: 0.34.0
     obr: true
     mvp: true
     isolated: true


### PR DESCRIPTION
## Why?

This is to resolve the runtime error of `java.lang.NoClassDefFoundError: com.ibm.dataaccess.ByteArrayUnmarshaller` at runtime, which is caused by the package not being imported in the db2 manager.