### PR TITLE
bumped version of jta to the new package version

### DIFF
--- a/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager/build.gradle
@@ -9,7 +9,7 @@ version = '0.34.0'
 dependencies {
 	// implementation project(':galasa-managers-core-parent:dev.galasa.artifact.manager')
     implementation 'com.ibm.db2.jcc:db2jcc:db2jcc4'
-    implementation 'dev.galasa:jta:1.1'
+    implementation 'dev.galasa:jta:1.2'
 }
 
 // Note: These values are consumed by the parent build process


### PR DESCRIPTION
## Why?

to resolve the outdated dependency in [#1897](https://github.com/galasa-dev/projectmanagement/issues/1897)