### PR TITLE
use correct cics tag used in ivts

### DIFF
--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/build.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa SDV Manager IVT'
 
-version = '0.34.0'
+version = '0.35.0'
 
 dependencies {
     implementation project (':galasa-managers-cicsts-parent:dev.galasa.cicsts.ceci.manager')

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/src/main/java/dev/galasa/sdv/manager/ivt/SdvManagerIVT.java
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/src/main/java/dev/galasa/sdv/manager/ivt/SdvManagerIVT.java
@@ -11,9 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.galasa.BeforeClass;
 import dev.galasa.Test;
-import dev.galasa.cicsts.CicsRegion;
 import dev.galasa.cicsts.CicsTerminal;
-import dev.galasa.cicsts.ICicsRegion;
 import dev.galasa.cicsts.ICicsTerminal;
 import dev.galasa.core.manager.Logger;
 import dev.galasa.sdv.ISdvUser;
@@ -25,9 +23,6 @@ import dev.galasa.sdv.SdvUser;
    
     @Logger
     public Log logger;
-
-    @CicsRegion(cicsTag = "A")
-    public ICicsRegion cics;
 
     @CicsTerminal(cicsTag = "A")
     public ICicsTerminal terminal;

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/src/main/java/dev/galasa/sdv/manager/ivt/SdvManagerIVT.java
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/src/main/java/dev/galasa/sdv/manager/ivt/SdvManagerIVT.java
@@ -26,13 +26,13 @@ import dev.galasa.sdv.SdvUser;
     @Logger
     public Log logger;
 
-    @CicsRegion
+    @CicsRegion(cicsTag = "A")
     public ICicsRegion cics;
 
-    @CicsTerminal
+    @CicsTerminal(cicsTag = "A")
     public ICicsTerminal terminal;
 
-    @SdvUser(roleTag = "role1")
+    @SdvUser(cicsTag = "A", roleTag = "R1")
     public ISdvUser user1;
 
     private static final String SDV_TCPIPSERVICE_NAME = "SDVXSDT";

--- a/release.yaml
+++ b/release.yaml
@@ -328,7 +328,7 @@ managers:
     codecoverage: true
   
   - artifact: dev.galasa.sdv.manager.ivt
-    version: 0.34.0
+    version: 0.35.0
     obr: true
     mvp: true
     isolated: true


### PR DESCRIPTION
The SDV IVT test hasn't been used yet, I'm currently looking into it.

@jadecarino pointed me towards https://github.com/galasa-dev/integratedtests which shows me that the `A` tag is used to obtain the test CICS region in the IVTs, so I am making changes so my test correctly obtains the region to use in test.

I will further make changes on https://github.com/galasa-dev/integratedtests to bring the IVT into the suite, and provide CPS properties for the run.