### PR TITLE
Bump managers to 0.36.0

### DIFF
--- a/galasa-managers-parent/build.gradle
+++ b/galasa-managers-parent/build.gradle
@@ -9,7 +9,7 @@ plugins {
 // It is used as the version number of the managers bundle, which contains a yaml
 // file which is in a release.yaml, but published to maven, so that the OBR build 
 // can pick it up later.
-version = "0.35.0"
+version = "0.36.0"
 
 // A configuration to publish the merge exec into
 configurations {
@@ -193,7 +193,7 @@ publishing {
                 name = "Manifest for managers bundle versions"
                 artifactId = "dev.galasa.managers.manifest"
                 groupId = 'dev.galasa'
-				version = "0.35.0"
+				version = "0.36.0"
                 description = "Conveys bundle version information to OBR builds."
                 licenses {
                     license {

--- a/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+++ b/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     api            'dev.galasa:dev.galasa:0.34.0'
-    implementation 'dev.galasa:dev.galasa.framework:0.35.0'
+    implementation 'dev.galasa:dev.galasa.framework:0.36.0'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'org.osgi:org.osgi.core:6.0.0'
     implementation 'org.osgi:org.osgi.service.component.annotations:1.3.0'


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1905