### PR TITLE
use dedicated cics region for test

### DIFF
--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/src/main/java/dev/galasa/sdv/manager/ivt/SdvManagerIVT.java
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/src/main/java/dev/galasa/sdv/manager/ivt/SdvManagerIVT.java
@@ -24,10 +24,10 @@ import dev.galasa.sdv.SdvUser;
     @Logger
     public Log logger;
 
-    @CicsTerminal(cicsTag = "A")
+    @CicsTerminal(cicsTag = "SDVIVT")
     public ICicsTerminal terminal;
 
-    @SdvUser(cicsTag = "A", roleTag = "R1")
+    @SdvUser(cicsTag = "SDVIVT", roleTag = "R1")
     public ISdvUser user1;
 
     private static final String SDV_TCPIPSERVICE_NAME = "SDVXSDT";


### PR DESCRIPTION
Changing test to use a dedicated region for the SDV IVT, using a DSE. This DSE has been set up in the prod ecosystem CPS, using the same APPLID as the zos3270 test. I've opted to do it slightly differently, so I don't have to hardcode the APPLID in the test itself....I think this will work based on how I've used my own region for test before, but let me know if this isn't suitable.

The dedicated APPLID is at 730 at the moment, so this test will always pass as its essentially skipped. The dedicated region also has `SEC=NO`, which will cause this test to fail when it is eventually upgraded. So some thought will be required later on the test cics region to make this work.

Related integratedtests changes are here https://github.com/galasa-dev/integratedtests/pull/197