### PR TITLE
3270 terminals disconnect and re-connect between scenarios

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -75,7 +75,18 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
+  "results": {
+    "galasa-managers-parent/galasa-managers-database-parent/dev.galasa.db2.manager.ivt/README.md": [
+      {
+        "hashed_secret": "22199ec38c6bedb7616f8e42aa3ad6e9f196cd24",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
   "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/README.md
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/README.md
@@ -17,15 +17,19 @@ NOTE, the spacing and capitalisation must be exact at this time.  We will try to
 
 There are 4 flavours to the "given a terminal".  you can specify an ID for a terminal so that a feature file can operate multiple terminals in the same feature file.  You can also specify a zOS image tag to influence which image the terminal connects to.
 
-The default ID is A and the default tag is PRIMARY.
+The default ID is `A` and the default tag is `PRIMARY`.
 
-In all the following statements,  where you see `terminal` you can leave as default ID of A or code `terminal B` to point to a different terminal.
+In all the following statements,  where you see `terminal` you can leave as default ID of `A` or code `terminal B` to point to a different terminal.
 
 ### Move Cursor
   
 `AND move terminal cursor to field "xxxxxx"`
 
-Where xxxxxx is the text in an protected or unprotected field on the screen.
+Where `xxxxxx` is the text in an protected or unprotected field on the screen.
+
+`AND move terminal A cursor to field "xxxxxx"`
+
+As above, but for the terminal with an id of `A`
 
 ### Terminal keys
 
@@ -35,17 +39,25 @@ Where xxxxxx is the text in an protected or unprotected field on the screen.
 
 `AND press terminal key ENTER`
 
-`AND press terminal key PFxx` where xx is the PF number
+`AND press terminal key PFxx` where `xx` is the PF number
+
+`AND press terminal A key ENTER` where `A` is the id of the terminal to use.
 
 ### Type something
 
-`AND type "xxxxxx" on terminal` where xxxxx is what you want to type where the cursor is
+`AND type "xxxxxx" on terminal` where `xxxxx` is what you want to type where the cursor is
 
-`AND type "xxxxxx" on terminal in field labelled "yyyyyy"` where xxxxxx is the what you want to type,  yyyyyy is the field label.  WARNING, this will move the cursor.  It will locate ANY text yyyyyy and then press TAB and then type.
+`AND type "xxxxxx" on terminal A` where `A` is the id of the terminal to use.
+
+`AND type "xxxxxx" on terminal in field labelled "yyyyyy"` where `xxxxxx` is the what you want to type,  `yyyyyy` is the field label.  WARNING, this will move the cursor.  It will locate ANY text `yyyyyy` and then press TAB and then type.
+
+`AND type "xxxxxx" on terminal A in field labelled "yyyyyy"` where `A` is the id of the terminal to use.
 
 ### Wait for the keyboard to unlock
 
 `AND wait for terminal keyboard`
+
+`AND wait for terminal A keyboard`
 
 ### Wait for text on the screen
 
@@ -53,8 +65,13 @@ Where xxxxxx is the text in an protected or unprotected field on the screen.
 
 This will wait for the text to appear on the screen on any screen update.  WARNING, the keyboard may not be unlocked when this statement finishes.
 
+`THEN wait for "xxxxxx" in any terminal A field` where `A` is the id of the terminal to use.
+
 ### Check single text on screen
 
 `THEN check "xxxxxx" appears only once on terminal`
 
-This will search the screen for text xxxxxx and ensure it occurs once.  This is immediate, will not wait for updates.
+This will search the screen for text `xxxxxx` and ensure it occurs once.  This is immediate, will not wait for updates.
+
+`THEN check "xxxxxx" appears only once on terminal A` where `A` is the id of the terminal to use.
+

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa zOS 3270 Terminal Manager'
 
-version = '0.34.0'
+version = '0.36.0'
 
 dependencies {
     api            project(':galasa-managers-zos-parent:dev.galasa.zos3270.common')

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270CheckAppearsOnce.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270CheckAppearsOnce.java
@@ -38,6 +38,9 @@ public class Gherkin3270CheckAppearsOnce  implements IStatementOwner {
         }
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270Coordinator.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270Coordinator.java
@@ -2,15 +2,11 @@ package dev.galasa.zos3270.internal.gherkin;
 
 import java.util.*;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import dev.galasa.ManagerException;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.IGherkinExecutable;
 import dev.galasa.framework.spi.IStatementOwner;
 import dev.galasa.framework.spi.language.gherkin.GherkinTest;
-import dev.galasa.zos3270.TerminalInterruptedException;
 import dev.galasa.zos3270.Zos3270ManagerException;
 import dev.galasa.zos3270.internal.Zos3270ManagerImpl;
 import dev.galasa.zos3270.spi.Zos3270TerminalImpl;
@@ -22,8 +18,6 @@ public class Gherkin3270Coordinator {
     
     // The gherkin test is essentially a feature.
     private final GherkinTest feature;
-    
-    private final static Log logger = LogFactory.getLog(Gherkin3270Coordinator.class);
 
     // This coordinator keeps a reference of the terminals using the id that the gherkin scenario uses,
     // which is different to the underlying terminal id.

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270Coordinator.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270Coordinator.java
@@ -6,6 +6,7 @@ import dev.galasa.ManagerException;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.IGherkinExecutable;
 import dev.galasa.framework.spi.IStatementOwner;
+import dev.galasa.framework.spi.language.gherkin.GherkinMethod;
 import dev.galasa.framework.spi.language.gherkin.GherkinTest;
 import dev.galasa.zos3270.Zos3270ManagerException;
 import dev.galasa.zos3270.internal.Zos3270ManagerImpl;
@@ -64,10 +65,16 @@ public class Gherkin3270Coordinator {
 
     public void provisionGenerate() throws Zos3270ManagerException {
         // Provision any terminals that are Given
-        for(IGherkinExecutable executable : this.feature.getAllExecutables()) {
-            Object owner = executable.getOwner();
-            if (owner instanceof Gherkin3270GivenTerminal) {
-                ((Gherkin3270GivenTerminal)owner).provision(executable);
+        List<GherkinMethod> methods = this.feature.getMethods();
+        for( GherkinMethod method : methods ) {
+
+            List<IGherkinExecutable> executables = method.getExecutables();
+            for(IGherkinExecutable executable : executables) {
+                Object owner = executable.getOwner();
+
+                if (owner instanceof Gherkin3270GivenTerminal) {
+                    ((Gherkin3270GivenTerminal)owner).provision(executable);
+                }
             }
         }
     }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270Credentials.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270Credentials.java
@@ -42,6 +42,9 @@ public class Gherkin3270Credentials  implements IStatementOwner {
         String credentialsId = AbstractManager.nulled(groups.get(0));
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }
@@ -69,6 +72,9 @@ public class Gherkin3270Credentials  implements IStatementOwner {
         String credentialsId = AbstractManager.nulled(groups.get(0));
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270GivenTerminal.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270GivenTerminal.java
@@ -18,6 +18,7 @@ import dev.galasa.framework.spi.language.gherkin.GherkinKeyword;
 import dev.galasa.zos3270.Zos3270ManagerException;
 import dev.galasa.zos3270.common.screens.TerminalSize;
 import dev.galasa.zos3270.internal.Zos3270ManagerImpl;
+import dev.galasa.zos3270.spi.NetworkException;
 import dev.galasa.zos3270.spi.Zos3270TerminalImpl;
 
 public class Gherkin3270GivenTerminal  implements IStatementOwner {
@@ -41,8 +42,13 @@ public class Gherkin3270GivenTerminal  implements IStatementOwner {
         if (terminal == null) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' was not provisioned!");
         }
+        
         if (!terminal.isConnected()) {
-            throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected to the host system");
+            try {
+                terminal.connect();
+            } catch (NetworkException ex ) {
+                throw new Zos3270ManagerException("Cannot connect terminal to host system.",ex);
+            }
         }
     }
 
@@ -59,6 +65,6 @@ public class Gherkin3270GivenTerminal  implements IStatementOwner {
             newTerminal = this.manager.generateTerminal(imageTag, true, terminalSize, alternateSize);
             this.gerkinCoordinator.registerTerminal(terminalId, newTerminal, imageTag);
             logger.info("zOS 3270 Terminal id '" + terminalId + "' as been provisioned for image tag '" + imageTag + "'");
-        }       
+        } 
     }
 }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270MoveCursor.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270MoveCursor.java
@@ -39,6 +39,9 @@ public class Gherkin3270MoveCursor  implements IStatementOwner {
 
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270PressBasicKeys.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270PressBasicKeys.java
@@ -35,6 +35,9 @@ public class Gherkin3270PressBasicKeys  implements IStatementOwner {
         String key = groups.get(1);
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270PressPfKeys.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270PressPfKeys.java
@@ -35,6 +35,9 @@ public class Gherkin3270PressPfKeys  implements IStatementOwner {
         String key = groups.get(1);
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270Type.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270Type.java
@@ -32,12 +32,15 @@ public class Gherkin3270Type  implements IStatementOwner {
         List<String> groups = executable.getRegexGroups();  
 
         String terminalId = Gherkin3270Coordinator.defaultTerminaId(groups.get(1));
-       String text = groups.get(0);
+        String text = groups.get(0);
         if (text.isEmpty()) {
             return;
         }
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270TypeInField.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270TypeInField.java
@@ -42,6 +42,9 @@ public class Gherkin3270TypeInField  implements IStatementOwner {
         }
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270WaitKeyboard.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270WaitKeyboard.java
@@ -34,6 +34,9 @@ public class Gherkin3270WaitKeyboard  implements IStatementOwner {
         String terminalId = Gherkin3270Coordinator.defaultTerminaId(groups.get(0));
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270WaitTextField.java
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.manager/src/main/java/dev/galasa/zos3270/internal/gherkin/Gherkin3270WaitTextField.java
@@ -38,6 +38,9 @@ public class Gherkin3270WaitTextField  implements IStatementOwner {
         }
 
         Zos3270TerminalImpl terminal = this.gerkinCoordinator.getTerminal(terminalId);
+        if (terminal == null ) {
+            throw new Zos3270ManagerException("Unable to get terminal "+terminalId);
+        }
         if (!terminal.isConnected()) {
             throw new Zos3270ManagerException("Terminal '" + terminalId + "' is not connected");
         }

--- a/release.yaml
+++ b/release.yaml
@@ -512,7 +512,7 @@ managers:
     codecoverage: true
     
   - artifact: dev.galasa.zos3270.manager
-    version: 0.34.0
+    version: 0.36.0
     obr: true
     javadoc: true
     bom: true


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?

See https://github.com/galasa-dev/projectmanagement/issues/1858

To get multiple scenarios working within a single feature, it is necessary to disconnect terminals when the scenario (method) has finished.

Hooking into the endMethod call, so that all connected terminals can be disconnected for gherkin test cases.

