### PR TITLE
Update release.yaml using the auto-generated release.yaml during local builds

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -224,7 +224,23 @@ function check_secrets {
     success "secrets audit complete"
 }
 
+function update_release_yaml {
+    h2 "Updating release.yaml"
+
+    # After running 'gradle build', a release.yaml file should have been automatically generated
+    generated_release_yaml="${BASEDIR}/galasa-managers-parent/build/release.yaml"
+    current_release_yaml="${BASEDIR}/release.yaml"
+
+    if [[ -f ${generated_release_yaml} ]]; then
+        cp ${generated_release_yaml} ${current_release_yaml}
+        success "Updated release.yaml OK"
+    else
+        warn "Failed to automatically generate release.yaml, please ensure any changed bundles have had their versions updated in ${current_release_yaml}"
+    fi
+}
+
 
 build_code
+update_release_yaml
 
 check_secrets

--- a/release.yaml
+++ b/release.yaml
@@ -1,8 +1,15 @@
 #
-# Copyright contributors to the Galasa project
+# Copyright contributors to the Galasa project 
 #
-# SPDX-License-Identifier: EPL-2.0
+
+# -----------------------------------------------------------
 #
+#                         WARNING
+#
+# This file is periodically re-generated from the contents of 
+# the repository, so don't make changes here manually please.
+# -----------------------------------------------------------
+
 
 apiVersion: galasa.dev/v1alpha
 kind: Release
@@ -14,522 +21,644 @@ managers:
 
 #
 # Manager 
-#  
+#
 
-  - artifact: dev.galasa.artifact.manager
-    version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.artifact.manager.ivt
-    version: 0.25.0
-    obr: true
-    mvp: true
-    isolated: true
-    
-  - artifact: dev.galasa.cicsts.manager
-    version: 0.32.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
 
-  - artifact: dev.galasa.cicsts.manager.ivt
-    version: 0.22.0
-    obr: true
-    mvp: true
-    bom: true
-    isolated: true
-    
   - artifact: dev.galasa.cicsts.ceci.manager
     version: 0.25.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.cicsts.ceci.manager.ivt
     version: 0.25.0
-    obr: true
-    mvp: true
-    bom: true
-    isolated: true
-    
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
   - artifact: dev.galasa.cicsts.ceda.manager
     version: 0.29.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.cicsts.ceda.manager.ivt
     version: 0.22.0
-    obr: true
-    mvp: true
-    isolated: true
-    
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
   - artifact: dev.galasa.cicsts.cemt.manager
     version: 0.25.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.cicsts.cemt.manager.ivt
     version: 0.22.0
-    obr: true
-    mvp: true
-    isolated: true
-    
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.cicsts.manager
+    version: 0.32.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.cicsts.manager.ivt
+    version: 0.25.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
+
   - artifact: dev.galasa.cicsts.resource.manager
     version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.cloud.manager
     version: 0.22.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.docker.manager
+    version: 0.34.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.docker.manager.ivt
+    version: 0.25.0
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.kubernetes.manager
+    version: 0.34.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.kubernetes.manager.ivt
+    version: 0.21.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.liberty.manager
+    version: 0.21.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.openstack.manager
+    version: 0.32.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.common
     version: 0.25.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.http.manager
+    version: 0.34.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.http.manager.ivt
+    version: 0.31.0
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.ipnetwork.manager
+    version: 0.25.0
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.mq.manager
+    version: 0.25.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.mq.manager.ivt
+    version: 0.21.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.artifact.manager
+    version: 0.34.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.artifact.manager.ivt
+    version: 0.25.0
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
   - artifact: dev.galasa.core.manager
     version: 0.31.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.core.manager.ivt
     version: 0.21.0
-    obr: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.textscan.manager
+    version: 0.34.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
 
   - artifact: dev.galasa.db2.manager
     version: 0.35.0
-    obr: true
-    bom: true
-    javadoc: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: false
 
   - artifact: dev.galasa.db2.manager.ivt
     version: 0.34.0
-    obr: true
-    mvp: true
-    isolated: true
-    
-  - artifact: dev.galasa.docker.manager
-    version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.docker.manager.ivt
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.eclipseruntime.manager
+    version: 0.18.0
+    obr:          false
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
+
+  - artifact: dev.galasa.eclipseruntime.ubuntu.manager
+    version: 0.18.0
+    obr:          false
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
+
+  - artifact: dev.galasa.sem.manager
     version: 0.25.0
-    obr: true
-    mvp: true
-    isolated: true
-    
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
+
+  - artifact: dev.galasa.java.manager
+    version: 0.21.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.java.ubuntu.manager
+    version: 0.21.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.java.windows.manager
+    version: 0.21.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
   - artifact: dev.galasa.elasticlog.manager
     version: 0.32.0
-    obr: true
-    bom: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.elasticlog.manager.ivt
     version: 0.21.0
-    obr: true
-    isolated: true
-    
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.phoenix2.manager
+    version: 0.31.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
   - artifact: dev.galasa.galasaecosystem.manager
     version: 0.34.0
-    obr: true
-    bom: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.galasaecosystem.manager.ivt
     version: 0.21.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.jmeter.manager
+    version: 0.25.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.jmeter.manager.ivt
+    version: 0.25.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.sdv.manager
+    version: 0.34.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.sdv.manager.ivt
+    version: 0.35.0
+    obr:          false
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
+
+  - artifact: dev.galasa.selenium.manager
+    version: 0.34.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.selenium.manager.ivt
+    version: 0.21.0
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.vtp.manager
+    version: 0.25.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.vtp.manager.ivt
+    version: 0.21.0
+    obr:          false
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
+
+  - artifact: dev.galasa.linux.manager
+    version: 0.21.0
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.linux.manager.ivt
+    version: 0.21.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.windows.manager
+    version: 0.21.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
 
   - artifact: dev.galasa.githubissue.manager
     version: 0.31.0
-    obr: true
-    mvp: false
-    bom: true
-    isolated: false
-    
-  - artifact: dev.galasa.http.manager
-    version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.http.manager.ivt
-    version: 0.31.0
-    obr: true
-    mvp: true
-    isolated: true
-    
-  - artifact: dev.galasa.ipnetwork.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.java.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.java.ubuntu.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.java.windows.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.jmeter.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.jmeter.manager.ivt
-    version: 0.25.0
-    obr: true
-    isolated: true
-    
-  - artifact: dev.galasa.kubernetes.manager
-    version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.kubernetes.manager.ivt
-    version: 0.21.0
-    obr: true
-    isolated: true
-    
-  - artifact: dev.galasa.liberty.manager
-    version: 0.21.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.linux.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.linux.manager.ivt
-    version: 0.21.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
 
-  - artifact: dev.galasa.mq.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
+  - artifact: dev.galasa.zos.manager
+    version: 0.34.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-  
-  - artifact: dev.galasa.mq.manager.ivt
-    version: 0.21.0
-    obr: true
-    bom: true
-    isolated: true
-    
-  - artifact: dev.galasa.openstack.manager
+
+  - artifact: dev.galasa.zos.manager.ivt
+    version: 0.28.0
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.zos3270.common
     version: 0.32.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.phoenix2.manager
-    version: 0.31.0
-    obr: true
-    bom: true
-    isolated: true
-  
-  - artifact: dev.galasa.sdv.manager
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      true
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.zos3270.manager
     version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-  
-  - artifact: dev.galasa.sdv.manager.ivt
-    version: 0.35.0
-    obr: true
-    mvp: true
-    isolated: true
-    
-  - artifact: dev.galasa.selenium.manager
-    version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.selenium.manager.ivt
+
+  - artifact: dev.galasa.zos3270.manager.ivt
     version: 0.21.0
-    obr: true
-    mvp: true
-    isolated: true
-    
-  - artifact: dev.galasa.sem.manager
-    version: 0.25.0
-    obr: true
-    bom: true
-    isolated: true
-    
-  - artifact: dev.galasa.textscan.manager
-    version: 0.34.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.windows.manager
-    version: 0.21.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
   - artifact: dev.galasa.zosbatch.rseapi.manager
     version: 0.34.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
-        
+
   - artifact: dev.galasa.zosbatch.zosmf.manager
     version: 0.34.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.zosconsole.oeconsol.manager
     version: 0.21.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.zosconsole.zosmf.manager
     version: 0.31.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.zosfile.rseapi.manager
     version: 0.34.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.zosfile.zosmf.manager
     version: 0.34.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
-    
-  - artifact: dev.galasa.zosliberty.manager
-    version: 0.34.0
-    obr: true
-    mvp: true
-    javadoc: true
-    bom: true
-    isolated: true
-    codecoverage: true
-    
+
   - artifact: dev.galasa.zosliberty.angel.manager
     version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-    
-  - artifact: dev.galasa.zos.manager
+
+  - artifact: dev.galasa.zosliberty.manager
     version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-    
-  - artifact: dev.galasa.zos.manager.ivt
-    version: 0.28.0
-    obr: true
-    mvp: true
-    isolated: true
-      
-  - artifact: dev.galasa.zosprogram.manager 
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
+
   - artifact: dev.galasa.zosmf.manager
     version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-    
+
+  - artifact: dev.galasa.zosprogram.manager
+    version: 0.25.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
   - artifact: dev.galasa.zosrseapi.manager
     version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.zossecurity.manager
     version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.zostsocommand.ssh.manager
     version: 0.21.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
-    
+
   - artifact: dev.galasa.zosunixcommand.ssh.manager
     version: 0.21.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
     codecoverage: true
-    
-  - artifact: dev.galasa.zos3270.common
-    version: 0.32.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zos3270.manager
-    version: 0.34.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-    
-  - artifact: dev.galasa.zos3270.manager.ivt
-    version: 0.21.0
-    obr: true
-    mvp: true
-    isolated: true
-
-  - artifact: dev.galasa.vtp.manager
-    version: 0.25.0
-    obr: true
-    javadoc: true
-    bom: true
-    mvp: true
-    isolated: true


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1902

## Changes
- Gradle builds generate a release.yaml based on the versions of all bundles in the managers project, so the build-locally script now copies that file into the actual release.yaml file, which removes the need to manually update bundle versions in the release.yaml.
- Updated the release.yaml based on the results from running the modified build-locally script