### PR TITLE
Fix GH workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
-            dockerRepository=harbor.galasa.dev
+            dockerRepository=ghcr.io
             tag=${{ env.IMAGE_TAG }}
 
       - name: Recycle application in ArgoCD

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -44,6 +44,6 @@ jobs:
           load: true
           tags: managers:test
           build-args: |
-              dockerRepository=harbor.galasa.dev
+              dockerRepository=ghcr.io
               tag=main
     

--- a/dockerfiles/dockerfile
+++ b/dockerfiles/dockerfile
@@ -1,6 +1,6 @@
 ARG dockerRepository
 ARG tag
-FROM ${dockerRepository}/galasadev/galasa-extensions:${tag}
+FROM ${dockerRepository}/galasa-dev/extensions-maven-artefacts:${tag}
 
 COPY repo/ /usr/local/apache2/htdocs/
 COPY managers.githash /usr/local/apache2/htdocs/managers.githash

--- a/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/galasa-managers-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -58,6 +58,10 @@ repositories {
 }
 
 signing {
+    def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign publishing.publications
 }
 
@@ -108,8 +112,8 @@ publishing {
             
             if ("$targetMaven".startsWith('http')) {
                 credentials {
-                    username System.getenv('MAVENUSERNAME')
-                    password System.getenv('MAVENPASSWORD')
+                    username System.getenv("GITHUB_ACTOR")
+                    password System.getenv("GITHUB_TOKEN")
                 }
             }
         }


### PR DESCRIPTION
## Why?

- Add missing parts to gradle file for signing, it needs this to take the GPG info from the workflow and use it for signing.
- Update the GH workflow and dockerfile to use the new Extensions image that is now available in GHCR.