### PR TITLE
Add support for Gradle 8

### DIFF
--- a/galasa-managers-parent/build.gradle
+++ b/galasa-managers-parent/build.gradle
@@ -45,19 +45,27 @@ subprojects {
 }
 
 // Define the artifact
-def execFile = layout.buildDirectory.file('jacoco/jacocoMerge.exec')
-def execArtifact = artifacts.add('archives', execFile.get().asFile) {
+def mergedReportFile = layout.buildDirectory.file('reports/jacoco/jacocoMerge/jacocoMerge.xml')
+def mergedReportArtifact = artifacts.add('archives', mergedReportFile.get().asFile) {
     builtBy 'jacocoMerge'
 }
 
+task jacocoMerge(type: JacocoReport) {
+    gradle.projectsEvaluated {
+        // Get the jacocoTestReport tasks in all subprojects
+        def searchRecursively = true
+        def reportTasks = project.getTasksByName('jacocoTestReport', searchRecursively)
+        dependsOn reportTasks
 
-task jacocoMerge(type: JacocoMerge) {
-    doFirst {
-        // go through all the files and remove the ones that do not exist.   some managers do not have unit tests yet
-        executionData = executionData.filter({f -> f.exists()})
+        executionData.setFrom(executionData.filter({ it.exists() }))
+        sourceDirectories.setFrom(reportTasks.sourceDirectories)
+        classDirectories.setFrom(reportTasks.classDirectories)
     }
 
-    enabled = jacocoEnabled.toBoolean()
+    reports {
+        html.required = true
+        xml.required = true
+    }
 }
 
 repositories {
@@ -86,7 +94,7 @@ if (jacocoEnabled.toBoolean()) {
     publishing {
         publications {
             maven(MavenPublication) {
-                artifact execArtifact
+                artifact mergedReportArtifact
                 
                 groupId = 'codecoverage'
                 artifactId = 'manager-unit-tests'
@@ -108,7 +116,7 @@ if (jacocoEnabled.toBoolean()) {
 }
 
 
-def manifestFilePath = "$buildDir/release.yaml"
+def manifestFile = layout.buildDirectory.file("release.yaml").get().asFile
 
 def header = """#
 # Copyright contributors to the Galasa project 
@@ -145,14 +153,13 @@ task buildReleaseYaml() {
         if ( !buildDir.exists() ) {
             buildDir.mkdirs()
         }
-        def manifest_file = new File(manifestFilePath)
-        if (!manifest_file.exists()){
-            manifest_file.createNewFile()
+        if (!manifestFile.exists()){
+            manifestFile.createNewFile()
         } else {
-            manifest_file.delete()
-            manifest_file.createNewFile()
+            manifestFile.delete()
+            manifestFile.createNewFile()
         }
-        manifest_file.append(header)
+        manifestFile.append(header)
     }
 
 
@@ -173,7 +180,7 @@ task buildReleaseYaml() {
             doLast {
                 // Some projects don't have a version property... as they are parent projects mostly.
                 if (version != 'unspecified') {
-                    def f = new File(manifestFilePath)
+                    def f = manifestFile
                     f.append("\n\n  - artifact: $projectName")
                     f.append("\n    version: $version")
                     if (includeInOBR != '') {
@@ -200,7 +207,7 @@ task buildReleaseYaml() {
     }
 }
 
-def myReleaseYaml = artifacts.add('release_metadata', file("$buildDir/release.yaml")) {
+def myReleaseYaml = artifacts.add('release_metadata', manifestFile) {
     builtBy 'buildReleaseYaml'
 }
 

--- a/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
+++ b/galasa-managers-parent/buildSrc/src/main/groovy/galasa.manager.gradle
@@ -28,4 +28,15 @@ test {
     jacoco {
         enabled = jacocoEnabled.toBoolean()
     }
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    enabled = jacocoEnabled.toBoolean()
+    dependsOn test
+
+    reports {
+        html.required = true
+        xml.required = true
+    }
 }

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager/build.gradle
@@ -7,15 +7,20 @@ plugins {
 
 description = 'Galasa SDV Manager'
 
-version = '0.34.0'
+version = '0.36.0'
 
 checkstyle {
     configFile = file("config/checkstyle/checkstyle.xml") 
     toolVersion = "10.14.2"
 }
-configurations.all {
-    attributes {
-        attribute(Attribute.of('org.gradle.jvm.environment', String), 'standard-jvm')
+
+// Apply a workaround to get checkstyle working with Gradle 6.x,
+// this workaround is not required for later versions of Gradle.
+if (project.getGradle().getGradleVersion().compareTo("7.0") < 0) {
+    configurations.all {
+        attributes {
+            attribute(Attribute.of('org.gradle.jvm.environment', String), 'standard-jvm')
+        }
     }
 }
 

--- a/release.yaml
+++ b/release.yaml
@@ -403,7 +403,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.sdv.manager
-    version: 0.34.0
+    version: 0.36.0
     obr:          true
     mvp:          true
     bom:          true


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1652

## Changes
- Added a condition around a workaround applied in the SDV manager's build.gradle to allow the checkstyle plugin to work with Gradle 6, which breaks Gradle 7 and 8 builds
- Updated the `jacocoMerge` task since the `JacocoMerge` task was deprecated in favour of `JacocoReport`
  - `JacocoReport` cannot produce a `.exec` file, so the published managers code coverage report artifact is now in XML format
- Enabled Jacoco report generation for subprojects applying the `galasa.manager` plugin