### PR TITLE
Iss1956 - Add floating IP pool to request to create floating IP

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa Openstack Manager'
 
-version = '0.32.0'
+version = '0.36.0'
 
 dependencies {
     api            project(':galasa-managers-comms-parent:dev.galasa.ipnetwork.manager')

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
@@ -239,7 +239,7 @@ public class OpenstackHttpClient {
         try {
             checkToken();
 
-            // *** Retrieve a list of the networks available and select one
+            // *** Retrieve a list of the servers available and select one
 
             HttpGet get = new HttpGet(this.openstackComputeUri + "/servers");
             get.addHeader(this.openstackToken.getHeader());
@@ -578,7 +578,7 @@ public class OpenstackHttpClient {
         try {
             checkToken();
 
-            // *** Retrieve a list of the images
+            // *** Retrieve a list of the flavours
 
             HttpGet get = new HttpGet(this.openstackComputeUri + "/flavors");
             get.addHeader(this.openstackToken.getHeader());
@@ -588,7 +588,7 @@ public class OpenstackHttpClient {
                 String entity = EntityUtils.toString(response.getEntity());
 
                 if (status.getStatusCode() != HttpStatus.SC_OK) {
-                    throw new OpenstackManagerException("OpenStack list image failed - " + status);
+                    throw new OpenstackManagerException("OpenStack list flavour failed - " + status);
                 }
 
                 Flavors flavours = gson.fromJson(entity, Flavors.class);
@@ -633,7 +633,7 @@ public class OpenstackHttpClient {
                 String entity = EntityUtils.toString(response.getEntity());
 
                 if (status.getStatusCode() != HttpStatus.SC_CREATED) {
-                    throw new OpenstackManagerException("OpenStack list image failed - " + status);
+                    throw new OpenstackManagerException("OpenStack create floating ip failed - " + status);
                 }
 
                 FloatingipRequestResponse fipResponse = this.gson.fromJson(entity, FloatingipRequestResponse.class);
@@ -684,7 +684,7 @@ public class OpenstackHttpClient {
         } catch (OpenstackManagerException e) {
             throw e;
         } catch (Exception e) {
-            throw new OpenstackManagerException("Unable to list floating ips ", e);
+            throw new OpenstackManagerException("Unable to list networks ", e);
         }
     }
 

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
@@ -60,6 +60,7 @@ import dev.galasa.openstack.manager.internal.json.ServersResponse;
 import dev.galasa.openstack.manager.internal.json.User;
 import dev.galasa.openstack.manager.internal.properties.OpenStackCredentialsId;
 import dev.galasa.openstack.manager.internal.properties.OpenStackDomainName;
+import dev.galasa.openstack.manager.internal.properties.OpenStackFloatingIPPool;
 import dev.galasa.openstack.manager.internal.properties.OpenStackIdentityUri;
 import dev.galasa.openstack.manager.internal.properties.OpenStackProjectName;
 
@@ -614,9 +615,12 @@ public class OpenstackHttpClient {
         try {
             checkToken();
 
+            String fipPool = OpenStackFloatingIPPool.get();
+
             Floatingip fip = new Floatingip();
             fip.port_id = port.id;
             fip.floating_network_id = network.id;
+            fip.floating_ip_address = fipPool;
             fip.description = "galasa_run=" + this.framework.getTestRunName();
 
             FloatingipRequestResponse fipRequest = new FloatingipRequestResponse();

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/BuildTimeout.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/BuildTimeout.java
@@ -22,8 +22,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * default value is 10 minutes
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class BuildTimeout extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxArchivesDirectory.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxArchivesDirectory.java
@@ -23,8 +23,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * Default is /opt/archives
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class LinuxArchivesDirectory extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxAvailablityZone.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxAvailablityZone.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is nova
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class LinuxAvailablityZone extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxCredentials.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxCredentials.java
@@ -27,8 +27,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is OPENSTACKSSH
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class LinuxCredentials extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxFlavor.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxFlavor.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is m1.medium
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class LinuxFlavor extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxImageCapabilities.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxImageCapabilities.java
@@ -32,8 +32,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is no capabilities
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class LinuxImageCapabilities extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxImages.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxImages.java
@@ -32,8 +32,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * There are no defaults
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class LinuxImages extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxKeyPair.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxKeyPair.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * There is no default
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class LinuxKeyPair extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxName.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxName.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is the same as the imagename
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class LinuxName extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxSecurityGroups.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/LinuxSecurityGroups.java
@@ -29,8 +29,6 @@ import java.util.Arrays;
  * <p>
  * There is no default
  * </p>
- * 
- * @author James Davies
  *
  */
 public class LinuxSecurityGroups extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/MaximumInstances.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/MaximumInstances.java
@@ -22,8 +22,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * default value is 2 instaces
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class MaximumInstances extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/NamePool.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/NamePool.java
@@ -30,8 +30,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * default value is GALASA{0-9}{0-9}
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class NamePool extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackCredentialsId.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackCredentialsId.java
@@ -23,8 +23,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * default value is openstack
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class OpenStackCredentialsId extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackDomainName.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackDomainName.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * There is no default
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class OpenStackDomainName extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackEnabled.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackEnabled.java
@@ -23,8 +23,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * default value is true
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class OpenStackEnabled extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackFloatingIPPool.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackFloatingIPPool.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.openstack.manager.internal.properties;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.cps.CpsProperties;
+import dev.galasa.openstack.manager.OpenstackManagerException;
+
+/**
+ * OpenStack Floating IP Pool
+ * <p>
+ * The Openstack Floating IP Pool that the OpenStack Manager will use
+ * to create a Floating IP address within.
+ * </p>
+ * <p>
+ * The property is:-<br>
+ * <br>
+ * openstack.server.floatingip.pool=my_network_name
+ * </p>
+ * <p>
+ * There is no default
+ * </p>
+ *
+ */
+public class OpenStackFloatingIPPool extends CpsProperties {
+
+    public static String get()
+            throws ConfigurationPropertyStoreException, OpenstackManagerException {
+        return getStringNulled(OpenstackPropertiesSingleton.cps(), "server", "floatingip.pool");
+    }
+
+}

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackIdentityUri.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackIdentityUri.java
@@ -25,8 +25,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * There is no default
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class OpenStackIdentityUri extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackLinuxPriority.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackLinuxPriority.java
@@ -23,8 +23,6 @@ import dev.galasa.framework.spi.cps.CpsProperties;
  * <p>
  * default value is 1
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class OpenStackLinuxPriority extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackProjectName.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackProjectName.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * There is no default
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class OpenStackProjectName extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsAvailablityZone.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsAvailablityZone.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is nova
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class WindowsAvailablityZone extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsCredentials.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsCredentials.java
@@ -27,8 +27,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is OPENSTACKSSH
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class WindowsCredentials extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsFlavor.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsFlavor.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is m1.medium
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class WindowsFlavor extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsImageCapabilities.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsImageCapabilities.java
@@ -32,8 +32,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is no capabilities
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class WindowsImageCapabilities extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsImages.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsImages.java
@@ -30,8 +30,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * There are no defaults
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class WindowsImages extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsKeyPair.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsKeyPair.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * There is no default
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class WindowsKeyPair extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsName.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsName.java
@@ -26,8 +26,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * The default is the same as the imagename
  * </p>
- * 
- * @author Michael Baylis
  *
  */
 public class WindowsName extends CpsProperties {

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsSecurityGroups.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/WindowsSecurityGroups.java
@@ -28,8 +28,6 @@ import dev.galasa.openstack.manager.OpenstackManagerException;
  * <p>
  * There is no default
  * </p>
- * 
- * @author James Davies
  *
  */
 public class WindowsSecurityGroups extends CpsProperties {

--- a/release.yaml
+++ b/release.yaml
@@ -160,7 +160,7 @@ managers:
     codecoverage: true
 
   - artifact: dev.galasa.openstack.manager
-    version: 0.32.0
+    version: 0.36.0
     obr:          true
     mvp:          false
     bom:          true


### PR DESCRIPTION
## Why?

- To fix defect [OpenStack create floating IP Bad Request](https://github.com/galasa-dev/projectmanagement/issues/1956). Now that there is more than one external network available in OpenStack (created due to requirements for an external ipv6 network), the request to create a floating IP must include which floating IP pool to create it in. I have adapted the Openstack Manager to do this and created a CPS property for the floating IP pool value so it's configurable.
- Also corrected comments and exceptions in the Openstack manager that did not match what they were doing. 
- Removed remaining `@author` tags in this bundle as upgrading it anyway.
- Upgraded version in release.yaml and build.gradle.