### PR TITLE
Provide network name in CPS to get network ID

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
@@ -615,12 +615,9 @@ public class OpenstackHttpClient {
         try {
             checkToken();
 
-            String fipPool = OpenStackFloatingIPPool.get();
-
             Floatingip fip = new Floatingip();
             fip.port_id = port.id;
             fip.floating_network_id = network.id;
-            fip.floating_ip_address = fipPool;
             fip.description = "galasa_run=" + this.framework.getTestRunName();
 
             FloatingipRequestResponse fipRequest = new FloatingipRequestResponse();

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
@@ -60,7 +60,6 @@ import dev.galasa.openstack.manager.internal.json.ServersResponse;
 import dev.galasa.openstack.manager.internal.json.User;
 import dev.galasa.openstack.manager.internal.properties.OpenStackCredentialsId;
 import dev.galasa.openstack.manager.internal.properties.OpenStackDomainName;
-import dev.galasa.openstack.manager.internal.properties.OpenStackFloatingIPPool;
 import dev.galasa.openstack.manager.internal.properties.OpenStackIdentityUri;
 import dev.galasa.openstack.manager.internal.properties.OpenStackProjectName;
 

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackServerImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackServerImpl.java
@@ -32,6 +32,7 @@ import dev.galasa.openstack.manager.internal.json.Port;
 import dev.galasa.openstack.manager.internal.json.Server;
 import dev.galasa.openstack.manager.internal.json.ServerRequest;
 import dev.galasa.openstack.manager.internal.properties.BuildTimeout;
+import dev.galasa.openstack.manager.internal.properties.OpenStackNetworkName;
 
 public abstract class OpenstackServerImpl {
 
@@ -315,8 +316,8 @@ public abstract class OpenstackServerImpl {
             }
 
             // *** Locate the external network
-            Network network = this.openstackHttpClient.findExternalNetwork(null); // TODO provide means to specify
-            // network
+            String networkName = OpenStackNetworkName.get();
+            Network network = this.openstackHttpClient.findExternalNetwork(networkName);
 
             if (network == null) {
                 throw new OpenstackManagerException("Unable to select an external network to allocate a floatingip on");

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackNetworkName.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/properties/OpenStackNetworkName.java
@@ -10,26 +10,23 @@ import dev.galasa.framework.spi.cps.CpsProperties;
 import dev.galasa.openstack.manager.OpenstackManagerException;
 
 /**
- * OpenStack Floating IP Pool
- * <p>
- * The Openstack Floating IP Pool that the OpenStack Manager will use
- * to create a Floating IP address within.
- * </p>
- * <p>
- * The property is:-<br>
- * <br>
- * openstack.server.floatingip.pool=my_network_name
- * </p>
- * <p>
+ * OpenStack Network name
+ * 
+ * The Openstack Network name that the OpenStack Manager will use
+ * to create a Floating IP address within. The Network name is used
+ * to get the Network ID.
+ * 
+ * The property is:
+ * <code>openstack.network.name=my_network_name</code>
+ * 
  * There is no default
- * </p>
  *
  */
-public class OpenStackFloatingIPPool extends CpsProperties {
+public class OpenStackNetworkName extends CpsProperties {
 
     public static String get()
             throws ConfigurationPropertyStoreException, OpenstackManagerException {
-        return getStringNulled(OpenstackPropertiesSingleton.cps(), "server", "floatingip.pool");
+        return getStringNulled(OpenstackPropertiesSingleton.cps(), "network", "name");
     }
 
 }


### PR DESCRIPTION
## Why?
Attempting to fix https://github.com/galasa-dev/projectmanagement/issues/1956

- Remove changes from yesterday in OpenstackHttpClient.
- Add CPS property for providing the Network Name you wish to allocate a Floating IP on, that is then used to get the Network ID. There is now two external Networks available instead of one so the previous logic did not use a configurable  Network Name and simply picked the first (and only) external network. There are now two and assuming the results come back in alphabetical order, the wrong network is always selected.
- Versions already at 0.36.0.
- Fixed Javadoc as per Mike's comments.