### PR TITLE
Iss1956 - Fix Openstack Manager choosing the first external network it finds in the response to `/networks`

### DIFF
--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackHttpClient.java
@@ -682,11 +682,6 @@ public class OpenstackHttpClient {
                         if (externalNetwork != null && externalNetwork.equals(network.name)) {
                             logger.debug("Selected network: " + network.id);
                             return network;
-                        } else {
-                            if (network.route_external) {
-                                logger.debug("External network name was not provided in CPS or no match was found. Selected network: " + network.id);
-                                return network;
-                            }
                         }
                     }
                 }

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackServerImpl.java
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/src/main/java/dev/galasa/openstack/manager/internal/OpenstackServerImpl.java
@@ -317,8 +317,10 @@ public abstract class OpenstackServerImpl {
 
             // *** Locate the external network
             String networkName = OpenStackNetworkName.get();
+            if (networkName == null) {
+                throw new OpenstackManagerException("The external network name to allocate a floatingip on was not provided in the CPS");
+            }
             Network network = this.openstackHttpClient.findExternalNetwork(networkName);
-
             if (network == null) {
                 throw new OpenstackManagerException("Unable to select an external network to allocate a floatingip on");
             }


### PR DESCRIPTION
## Why?

To fix https://github.com/galasa-dev/projectmanagement/issues/1956 -
The OpenstackHttpClient class findExternalNetwork method does a GET request to the `/networks` endpoint which returns an array of Network objects the user has access to. It should loop through each one, and select one if its name matches the name provided in the CPS. The `else` clause in the if statement that I have removed meant that the if it checked the first network, and that didn't match the name, it would just select it anyway because it's an external network. I have removed this so it will loop through all Networks found. If none match, null would be returned, and the manager would throw an exception anyway.

Added an exception also for if the external network name has not been set in the CPS as this is now required to avoid simply selecting the first network returned (which would be in alphabetical order).