### PR TITLE
Add CPS prop to configure the timeout of nested ecosystem manager test runs

### DIFF
--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa Ecosystem Manager'
 
-version = '0.34.0'
+version = '0.36.0'
 
 dependencies {
     implementation 'commons-io:commons-io:2.16.1'

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/LocalEcosystemImpl.java
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/LocalEcosystemImpl.java
@@ -56,6 +56,7 @@ import dev.galasa.galasaecosystem.internal.properties.GalasaBootVersion;
 import dev.galasa.galasaecosystem.internal.properties.IsolatedFullZip;
 import dev.galasa.galasaecosystem.internal.properties.IsolatedMvpZip;
 import dev.galasa.galasaecosystem.internal.properties.MavenUseDefaultLocalRepository;
+import dev.galasa.galasaecosystem.internal.properties.RunsTimeout;
 import dev.galasa.galasaecosystem.internal.properties.RuntimeRepo;
 import dev.galasa.galasaecosystem.internal.properties.RuntimeVersion;
 import dev.galasa.galasaecosystem.internal.properties.SimBankTestsVersion;
@@ -101,6 +102,8 @@ public abstract class LocalEcosystemImpl extends AbstractEcosystemImpl implement
     private final RunIdPrefixImpl runIdPrefix;
     
     private IFramework framework;
+
+    private int runsTimeout;
 
     public LocalEcosystemImpl(@NotNull GalasaEcosystemManagerImpl manager, 
             @NotNull String tag,
@@ -171,6 +174,7 @@ public abstract class LocalEcosystemImpl extends AbstractEcosystemImpl implement
 
             this.galasaBootVersion = GalasaBootVersion.get();
             this.simplatformVersion = SimplatformVersion.get();
+            this.runsTimeout = RunsTimeout.get();
 
             switch(this.isolationInstallation) {
                 case Full:
@@ -382,7 +386,7 @@ public abstract class LocalEcosystemImpl extends AbstractEcosystemImpl implement
 
     @Override
     public JsonObject waitForRun(String runName) throws GalasaEcosystemManagerException {
-        return waitForRun(runName, 3);
+        return waitForRun(runName, runsTimeout);
     }
 
     @Override

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/properties/RunsTimeout.java
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/src/main/java/dev/galasa/galasaecosystem/internal/properties/RunsTimeout.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.galasaecosystem.internal.properties;
+
+import dev.galasa.framework.spi.cps.CpsProperties;
+import dev.galasa.galasaecosystem.GalasaEcosystemManagerException;
+
+/**
+ * Timeout for Galasa Ecosystem manager nested test runs
+ *
+ * In minutes, how long the Galasa Ecosystem manager should wait for nested runs to complete before
+ * timing out. The default timeout value is 3 minutes.
+ *
+ * The property is:-
+ * <code>galasaecosystem.runs.timeout</code>
+ *
+ */
+public class RunsTimeout extends CpsProperties {
+
+    private static final int DEFAULT_TIMEOUT_MINUTES = 3;
+
+    public static int get() throws GalasaEcosystemManagerException {
+        return getIntWithDefault(GalasaEcosystemPropertiesSingleton.cps(), DEFAULT_TIMEOUT_MINUTES, "runs", "timeout");
+    }
+
+}

--- a/release.yaml
+++ b/release.yaml
@@ -367,7 +367,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.galasaecosystem.manager
-    version: 0.34.0
+    version: 0.36.0
     obr:          true
     mvp:          false
     bom:          true


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1957

## Changes
- Added `galasaecosystem.runs.timeout` CPS property to replace the hard-coded timeout of 3mins with a configurable value