### PR TITLE
Bump HTTP manager to 0.36.0

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -178,7 +178,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.http.manager
-    version: 0.34.0
+    version: 0.36.0
     obr:          true
     mvp:          true
     bom:          true


### PR DESCRIPTION
## Why?
Fixes a wiring error for the HTTP manager from changes in https://github.com/galasa-dev/managers/pull/968.