### PR TITLE
Ensure JVM server logs are saved.

### DIFF
--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.resource.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.resource.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa CICS/TS Resource Manager'
 
-version = '0.34.0'
+version = '0.37.0'
 
 dependencies {
     api            project (':galasa-managers-cicsts-parent:dev.galasa.cicsts.manager')

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.resource.manager/src/main/java/dev/galasa/cicsts/resource/internal/JvmserverImpl.java
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.resource.manager/src/main/java/dev/galasa/cicsts/resource/internal/JvmserverImpl.java
@@ -918,21 +918,13 @@ public class JvmserverImpl implements IJvmserver {
 
     @Override
     public void saveToResultsArchive(String rasPath) throws CicsJvmserverResourceException {
-        if (this.jvmprofile != null) {
-            this.jvmprofile.saveToResultsArchive(rasPath);
-        }
-        if (this.jvmLogLog != null) {
-            this.jvmLogLog.saveToResultsArchive(rasPath);
-        }
-        if (this.stdOutLog != null) {
-            this.stdOutLog.saveToResultsArchive(rasPath);
-        }
-        if (this.stdErrLog != null) {
-            this.stdErrLog.saveToResultsArchive(rasPath);
-        }
-        if (this.jvmTraceLog != null) {
-            this.jvmTraceLog.saveToResultsArchive(rasPath);
-        }
+        getJvmprofile().saveToResultsArchive(rasPath);
+
+        getJvmLog().saveToResultsArchive(rasPath);
+        getStdOut().saveToResultsArchive(rasPath);
+        getStdErr().saveToResultsArchive(rasPath);
+        getJvmTrace().saveToResultsArchive(rasPath);
+
         saveDiagnosticsToResultsArchive(rasPath);
         saveJavaLogsToResultsArchive(rasPath);
         if (isLiberty()) {


### PR DESCRIPTION
Fixes galasa-dev/projectmanagement#1972.

* Ensure that `saveToResultsArchive(String)` saves all the JVM logs, and not just the ones that were accessed during the test.
* Bumped managers version to 0.37.0