### PR TITLE
Bump cicsts.resource.manager to 0.37.0

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -97,7 +97,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.cicsts.resource.manager
-    version: 0.34.0
+    version: 0.37.0
     obr:          true
     mvp:          true
     bom:          true


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/managers/pull/977