### PR TITLE
Updating Managers build.gradles for new release.yaml values

### DIFF
--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.ceci.manager.ivt/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 ext.projectName=project.name
 ext.includeInOBR          = true
 ext.includeInMVP          = true
-ext.includeInBOM          = true
+ext.includeInBOM          = false
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager.ivt/build.gradle
@@ -23,8 +23,8 @@ dependencies {
 ext.projectName=project.name
 ext.includeInOBR          = true
 ext.includeInMVP          = true
-ext.includeInBOM          = true
-ext.includeInIsolated     = false
+ext.includeInBOM          = false
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false
 

--- a/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cicsts-parent/dev.galasa.cicsts.manager/build.gradle
@@ -22,8 +22,8 @@ dependencies {
 ext.projectName=project.name
 ext.includeInOBR          = true
 ext.includeInMVP          = true
-ext.includeInIsolated     = true
 ext.includeInBOM          = true
+ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
 ext.includeInJavadoc      = true
 

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/build.gradle
@@ -16,8 +16,8 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
-ext.includeInBOM          = true
-ext.includeInIsolated     = true
-ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = true
+ext.includeInMVP          = false
+ext.includeInBOM          = false
+ext.includeInIsolated     = false
+ext.includeInCodeCoverage = false
+ext.includeInJavadoc      = false

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.liberty.manager/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
-ext.includeInOBR          = true
+ext.includeInOBR          = false
 ext.includeInMVP          = false
 ext.includeInBOM          = false
 ext.includeInIsolated     = false

--- a/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-cloud-parent/dev.galasa.openstack.manager/build.gradle
@@ -27,4 +27,4 @@ ext.includeInMVP          = false
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.ipnetwork.manager/build.gradle
@@ -19,8 +19,8 @@ dependencies {
 ext.projectName=project.name
 ext.includeInOBR          = true
 ext.includeInMVP          = true
-ext.includeInBOM          = false
+ext.includeInBOM          = true
 ext.includeInIsolated     = true
-ext.includeInCodeCoverage = false
-ext.includeInJavadoc      = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = true
 

--- a/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/build.gradle
+++ b/galasa-managers-parent/galasa-managers-comms-parent/dev.galasa.mq.manager.ivt/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 ext.projectName=project.name
 ext.includeInOBR          = true
 ext.includeInMVP          = false
-ext.includeInBOM          = true
+ext.includeInBOM          = false
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.elasticlog.manager/build.gradle
@@ -22,4 +22,4 @@ ext.includeInMVP          = false
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true

--- a/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.phoenix2.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-logging-parent/dev.galasa.phoenix2.manager/build.gradle
@@ -21,6 +21,6 @@ ext.projectName=project.name
 ext.includeInOBR          = true
 ext.includeInMVP          = false
 ext.includeInBOM          = true
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-other-parent/dev.galasa.galasaecosystem.manager/build.gradle
@@ -32,5 +32,5 @@ ext.includeInMVP          = false
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true
 

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager.ivt/build.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager.ivt/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 ext.projectName=project.name
 ext.includeInOBR          = true
 ext.includeInMVP          = false
-ext.includeInBOM          = true
+ext.includeInBOM          = false
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = true

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager.ivt/build.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.jmeter.manager.ivt/build.gradle
@@ -23,4 +23,4 @@ ext.includeInMVP          = false
 ext.includeInBOM          = false
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
-ext.includeInJavadoc      = true
+ext.includeInJavadoc      = false

--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.vtp.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.vtp.manager/build.gradle
@@ -19,9 +19,9 @@ dependencies {
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
 ext.includeInOBR          = true
-ext.includeInMVP          = true
+ext.includeInMVP          = false
 ext.includeInBOM          = true
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = true
 

--- a/galasa-managers-parent/galasa-managers-windows-parent/dev.galasa.windows.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-windows-parent/dev.galasa.windows.manager/build.gradle
@@ -21,6 +21,6 @@ ext.projectName=project.name
 ext.includeInOBR          = true
 ext.includeInMVP          = false
 ext.includeInBOM          = false
-ext.includeInIsolated     = true
+ext.includeInIsolated     = false
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = false

--- a/galasa-managers-parent/galasa-managers-windows-parent/dev.galasa.windows.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-windows-parent/dev.galasa.windows.manager/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
 ext.projectName=project.name
-ext.includeInOBR          = true
+ext.includeInOBR          = false
 ext.includeInMVP          = false
 ext.includeInBOM          = false
 ext.includeInIsolated     = false

--- a/galasa-managers-parent/galasa-managers-workflow-parent/dev.galasa.githubissue.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-workflow-parent/dev.galasa.githubissue.manager/build.gradle
@@ -22,6 +22,6 @@ ext.includeInMVP          = true
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true
 
 

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zos3270.common/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 ext.projectName=project.name
 ext.includeInOBR          = true
 ext.includeInMVP          = true
-ext.includeInBOM          = false
+ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = false
 ext.includeInJavadoc      = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.rseapi.manager/build.gradle
@@ -23,4 +23,4 @@ ext.includeInMVP          = true
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosbatch.zosmf.manager/build.gradle
@@ -23,5 +23,5 @@ ext.includeInMVP          = true
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true
 

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.oeconsol.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.oeconsol.manager/build.gradle
@@ -22,7 +22,7 @@ ext.includeInMVP          = true
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true
 
 
 

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.zosmf.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosconsole.zosmf.manager/build.gradle
@@ -22,5 +22,5 @@ ext.includeInMVP          = true
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true
 

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.rseapi.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.rseapi.manager/build.gradle
@@ -25,4 +25,4 @@ ext.includeInMVP          = true
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.zosmf.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosfile.zosmf.manager/build.gradle
@@ -24,4 +24,4 @@ ext.includeInMVP          = true
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zostsocommand.ssh.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zostsocommand.ssh.manager/build.gradle
@@ -22,4 +22,4 @@ ext.includeInMVP          = true
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true

--- a/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosunixcommand.ssh.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-zos-parent/dev.galasa.zosunixcommand.ssh.manager/build.gradle
@@ -21,4 +21,4 @@ ext.includeInMVP          = true
 ext.includeInBOM          = true
 ext.includeInIsolated     = true
 ext.includeInCodeCoverage = true
-ext.includeInJavadoc      = false
+ext.includeInJavadoc      = true


### PR DESCRIPTION
## Why?

The Managers' release.yaml is generated using values from the different Managers' build.gradle files. I noticed some inconsistencies and so I have made the below changes:
- Excluded IVT projects from the Galasa BOM as they are not needed for compile
- Included all Manager projects in the Galasa BOM as they could be needed for compile
- Removed the dev.galasa.liberty.manager and dev.galasa.windows.manager from the Galasa OBR, BOM, MVP/Isolated, Javadoc and code coverage because these managers are firstly undocumented (no mention on the Galasa website) and also minimally implemented/not implemented at all
- Included all Managers with a helpful amount of Javadoc in the Javadocs and removed JMeter Manager from the Javadoc as it had no comments/descriptions
- Removed the dev.galasa.phoenix2.manager and dev.galasa.vtp.manager from the MVP/Isolated as they should be removed from the open source project anyway