### PR TITLE
add integratedtests logic into IVT itself

### DIFF
--- a/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/src/main/java/dev/galasa/sdv/manager/ivt/SdvManagerIVT.java
+++ b/galasa-managers-parent/galasa-managers-testingtools-parent/dev.galasa.sdv.manager.ivt/src/main/java/dev/galasa/sdv/manager/ivt/SdvManagerIVT.java
@@ -10,8 +10,11 @@ import org.apache.commons.logging.Log;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.galasa.BeforeClass;
+import dev.galasa.ProductVersion;
 import dev.galasa.Test;
+import dev.galasa.cicsts.CicsRegion;
 import dev.galasa.cicsts.CicsTerminal;
+import dev.galasa.cicsts.ICicsRegion;
 import dev.galasa.cicsts.ICicsTerminal;
 import dev.galasa.core.manager.Logger;
 import dev.galasa.sdv.ISdvUser;
@@ -23,6 +26,9 @@ import dev.galasa.sdv.SdvUser;
    
     @Logger
     public Log logger;
+
+    @CicsRegion(cicsTag = "SDVIVT")
+    public ICicsRegion cics;
 
     @CicsTerminal(cicsTag = "SDVIVT")
     public ICicsTerminal terminal;
@@ -40,11 +46,18 @@ import dev.galasa.sdv.SdvUser;
     @Test
     public void userUsesCeda() throws Exception {
 
-        terminal.type("CEDA DI G(SDVGRP)").enter().waitForTextInField(SDV_TCPIPSERVICE_NAME);
+        // Only run test if running on CICS 6.2+
+        if (!cics.getVersion().isEarlierThan(ProductVersion.v(750))) {
 
-        assertThat(terminal.searchText(SDV_TCPIPSERVICE_NAME))
-                .as("Expectation to see " + SDV_TCPIPSERVICE_NAME + " in terminal").isTrue();
-        terminal.pf3();
+            terminal.type("CEDA DI G(SDVGRP)").enter().waitForTextInField(SDV_TCPIPSERVICE_NAME);
+
+            assertThat(terminal.searchText(SDV_TCPIPSERVICE_NAME))
+                    .as("Expectation to see " + SDV_TCPIPSERVICE_NAME + " in terminal").isTrue();
+            terminal.pf3();
+        } else {
+            // Just pass the test if running on earlier CICS versions
+            assertThat(true).isTrue();
+        }
     }
   
  }


### PR DESCRIPTION
Adding this code because this logic was previously in the `integratedtests` repo, however, it is not possible to interact with the cics region within the `integratedtests` test that fires off this IVT, because only the IVT has the override props applied, `provision.type` must be set to `DSE` for the SDV test to work, as only once DSE is set, will the `SDVIVT` cics region tag be found.

Therefore the IVT itself will have to find the cics region, then do the product version comparison, to decide whether to run the test or not.