### PR TITLE
Updated temporary password used for Linux Manager in line with securi…

### DIFF
--- a/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager/build.gradle
+++ b/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa Linux Manager'
 
-version = '0.21.0'
+version = '0.38.0'
 
 dependencies {
     api            project(':galasa-managers-comms-parent:dev.galasa.ipnetwork.manager')

--- a/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager/src/main/java/dev/galasa/linux/internal/shared/LinuxSharedImage.java
+++ b/galasa-managers-parent/galasa-managers-unix-parent/dev.galasa.linux.manager/src/main/java/dev/galasa/linux/internal/shared/LinuxSharedImage.java
@@ -78,7 +78,7 @@ public class LinuxSharedImage implements ILinuxProvisionedImage {
                 throw new LinuxManagerException("useradd of username " + this.username + " failed:-\n" + response);
             }
 
-            String tempPassword = "ThisIsTheFutureOfTesting"; //Not a secret but this raises a vulnerability on server side runs. Issue has been raised to correct this //pragma: allowlist secret
+            String tempPassword = "ThisIsTheFutureOfTesting_123"; //Not a secret but this raises a vulnerability on server side runs. Issue has been raised to correct this //pragma: allowlist secret
             for(int i = 0; i < 4; i++) {
                 tempPassword = tempPassword + Integer.toString(this.random.nextInt(10));
             }

--- a/release.yaml
+++ b/release.yaml
@@ -448,7 +448,7 @@ managers:
     codecoverage: false
 
   - artifact: dev.galasa.linux.manager
-    version: 0.21.0
+    version: 0.38.0
     obr:          true
     mvp:          false
     bom:          true


### PR DESCRIPTION
…ty updates

## Why?

For https://github.com/galasa-dev/projectmanagement/issues/1995 I have updated the default password policies for our Linux VMs which run our tests. The temporary password used in the Linux Manager `ThisIsTheFutureOfTesting` is now no longer an acceptable password on the VMs so the tests were failing to provision. This new temporary password satisfies the requirements.

This temporary password be configurable via CPS which I'll look into in future.