### PR TITLE
build-locally.sh script update. sed not working on linux in same way as mac.

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -220,8 +220,19 @@ function check_secrets {
         error "Not all secrets found have been audited"
         exit 1  
     fi
-    sed -i '' '/[ ]*"generated_at": ".*",/d' .secrets.baseline
     success "secrets audit complete"
+
+    h2 "Removing the timestamp from the secrets baseline file so it doesn't always cause a git change."
+    mkdir -p temp
+    rc=$? 
+    check_exit_code $rc "Failed to create a temporary folder"
+    cat .secrets.baseline | grep -v "generated_at" > temp/.secrets.baseline.temp
+    rc=$? 
+    check_exit_code $rc "Failed to create a temporary file with no timestamp inside"
+    mv temp/.secrets.baseline.temp .secrets.baseline
+    rc=$? 
+    check_exit_code $rc "Failed to overwrite the secrets baseline with one containing no timestamp inside."
+    success "secrets baseline timestamp content has been removed ok"
 }
 
 function update_release_yaml {


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
sed isn't working the same on linux as it is on a mac.
So the detect-secrets stuff fails on a linux machine.

Replacing with grep -v which is far more likely to work in both places.